### PR TITLE
FCBHDBP-341 

### DIFF
--- a/load/CompleteCheck.py
+++ b/load/CompleteCheck.py
@@ -289,10 +289,10 @@ if (__name__ == '__main__'):
 	config = Config()
 	if len(sys.argv) > 2 and sys.argv[2].lower() == "full":
 		bucket = DownloadBucketList(config)
-		pathname = bucket.listBucket("dbp-prod")
+		pathname = bucket.listBucket(config.s3_bucket)
 		DBPRunFilesS3.simpleUpload(config, pathname, "text/plain")
 		dbpProdModified = datetime.utcnow()
-		pathname = bucket.listBucket("dbp-vid")
+		pathname = bucket.listBucket(config.s3_vid_bucket)
 		DBPRunFilesS3.simpleUpload(config, pathname, "text/plain")
 		dbpVidModified = dbpProdModified
 	elif len(sys.argv) > 2 and sys.argv[2].lower() == "fast":

--- a/load/Config.py
+++ b/load/Config.py
@@ -75,6 +75,7 @@ class Config:
 		self.s3_artifacts_bucket = self._get("s3.artifacts_bucket")
 		self.s3_aws_profile = self._getOptional("s3.aws_profile") 
 		self.s3_aws_role_arn = self._getOptional("s3.aws_role_arn") 
+		self.s3_aws_role_profile = self._getOptional("s3.aws_role_profile")
 
 		if programRunning in {"AudioHLS.py"}:
 			self.directory_audio_hls = self._getPath("directory.audio_hls") #"%s/FCBH/files/tmp" % (self.home)

--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -52,6 +52,8 @@ class InputFileset:
 	database = []
 	complete = []
 
+	def parseFilesetId(directory) :
+		return directory[:7] + "_" + directory[8:] + "-usx" if directory[8:10] == "ET" else directory
 
 	## parse command line, and return [InputFileset]
 	def filesetCommandLineParser(config, s3Client, lptsReader):
@@ -64,9 +66,18 @@ class InputFileset:
 		filesetPaths = sys.argv[3:]
 
 		for filesetPath in filesetPaths:
+			stocknumbers = PreValidate.getStockNumbersFromFile(filesetPath, location.replace("s3://", ""))
+			hasStocknumbersFile = True if len(stocknumbers) > 0 else False
 			filesetPath = filesetPath[:-1] if filesetPath.endswith("/") else filesetPath
-			filesetId = filesetPath.split("/")[-1]
-			filesetId = filesetId[:7] + "_" + filesetId[8:] + "-usx" if filesetId[8:10] == "ET" else filesetId
+			directory = filesetPath.split("/")[-1]
+			filesetId = directory
+
+			# the variable filesetId refers to a directory name. Originally, the directory name was an actual fileset id. Now,
+			# the directory name can be either (a) a fileset id; or (b) the name of a directory which contains a file called
+			# stocknumber.txt, which contains one or more stocknumbers associated with the content in that directory
+			if hasStocknumbersFile == False:
+				filesetId = InputFileset.parseFilesetId(directory)
+
 			(dataList, messages) = PreValidate.validateDBPELT(lptsReader, s3Client, location, filesetId, filesetPath)
 			for data in dataList:
 				inp = InputFileset(config, location, data.filesetId, filesetPath, data.damId, 

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -40,6 +40,25 @@ class PreValidateResult:
 
 class PreValidate:
 
+	def getStockNumbersFromFile(directory, bucket = "etl-development-input"):
+		config = Config.shared()
+		prefix = directory
+		session = boto3.Session(profile_name = config.s3_aws_profile)
+		s3Client = session.client('s3')
+
+		request = { 'Bucket': bucket, 'Prefix': prefix, 'MaxKeys': 1000 }
+		stocknumberArray = []
+
+		response = s3Client.list_objects_v2(**request)
+		for item in response.get('Contents', []):
+			objKey = item.get('Key')
+			(_, filename) = objKey.rsplit("/", 1)
+			if filename == 'stocknumber.txt':
+				stocknumberData = s3Client.get_object(Bucket=bucket, Key=objKey)
+				contents = stocknumberData['Body'].read()
+				stocknumberArray = contents.decode("utf-8").splitlines()
+
+		return stocknumberArray
 
 	## Validate input and return an errorList.
 	def validateLambda(lptsReader, directory, filenames):
@@ -48,13 +67,12 @@ class PreValidate:
 		result = None
 		stockNumber = preValidate.isTextStockNo(directory)
 		if stockNumber != None:
-			resultList = preValidate.validateUSXStockNo(stockNumber, filenames)
-			if resultList != None and len(resultList) > 0:
-				result = resultList[0]
+			stockResultList = preValidate.validateUSXStockList(stocknumberArrayFinal, filenames)
+			for stockResult in stockResultList:
+				preValidate.validateLPTS(stockResult)
 		else:
 			result = preValidate.validateFilesetId(directory)
-		if result != None:
-			preValidate.validateLPTS(result)
+
 		preValidate.addErrorMessages(directory, unicodeScript.errors)
 		return preValidate.formatMessages()
 
@@ -66,8 +84,12 @@ class PreValidate:
 		stockNumber = preValidate.isTextStockNo(directory)
 		if stockNumber != None:
 			filenames = unicodeScript.getFilenames(s3Client, location, fullPath)
-			sampleText = unicodeScript.readObject(s3Client, location, fullPath + "/" + filenames[0])
-			resultList = preValidate.validateUSXStockNo(stockNumber, filenames, sampleText)
+			sampleText =  unicodeScript.readObject(s3Client, location, fullPath + "/" + filenames[0]) if len(filenames) > 0 else None
+			stockResultList = preValidate.validateUSXStockList(stockNumber, filenames, sampleText)
+
+			for stockResult in stockResultList:
+				for result in stockResult:
+					resultList.append(result)
 		else:
 			result = preValidate.validateFilesetId(directory)
 			if result != None:
@@ -89,20 +111,43 @@ class PreValidate:
 					"1TI", "2TI", "TIT", "PHM", "HEB", "JAS", "1PE", "2PE", "1JN", "2JN", "3JN", "JUD", "REV" }
 
 
+	def isTextStockNoFromFile(self, directory):
+		stockNumberArray = PreValidate.getStockNumbersFromFile(directory)
+
+		stockNumberArrayFinal = []
+
+		if len(stockNumberArray) > 0:
+			for stockNumberItem in stockNumberArray:
+				stockNumberArrayFinal.append(stockNumberItem[:-3] + "/" + stockNumberItem[-3:])
+
+		return stockNumberArrayFinal
+
 	## determine if directory is USX text stockNo
 	def isTextStockNo(self, directory):
+		stockNumberArray = self.isTextStockNoFromFile(directory)
+
+		if len(stockNumberArray) > 0:
+			return stockNumberArray
+
 		parts = directory.split("_")
 		if len(parts) > 2:
 			stockNo = parts[-2]
 			if len(stockNo) > 5:
 				stockNumber = stockNo[:-3] + "/" + stockNo[-3:]
-				return stockNumber
+				return [stockNumber]
 			else:
 				self.errorMessage(directory, "Could not find a stock no.")
 		return None
 
 
-    ## Validate filesetId and return PreValidateResult
+	def validateUSXStockList(self, stockList, filenames, sampleText = None):
+		resultList = []
+		for stockListNumber in stockList:
+			result = self.validateUSXStockNo(stockListNumber, filenames, sampleText)
+			resultList.append(result)
+		return resultList
+
+	## Validate filesetId and return PreValidateResult
 	def validateFilesetId(self, filesetId):
 		filesetId1 = filesetId.split("-")[0]
 		damId = filesetId1.replace("_", "2")
@@ -174,14 +219,14 @@ class PreValidate:
 		else:
 			actualScript = None
 		ntResult = self._matchFilesToDamId(stockNo, "N", lptsRecord, scopeMap, bookIdMap, actualScript) # PreValidateResult or None
-		#if ntResult != None:
-		#	print("NT", ntResult.toString())
+		# if ntResult != None:
+		# 	print("NT", ntResult.toString())
 		otResult = self._matchFilesToDamId(stockNo, "O", lptsRecord, scopeMap, bookIdMap, actualScript) # PreValidateResult or None
-		#if otResult != None:
-		#	print("OT", otResult.toString())
+		# if otResult != None:
+		# 	print("OT", otResult.toString())
 		bothResults = self._combineMultiplePScope(stockNo, ntResult, otResult)
-		#for result in bothResults:
-		#	print("BOTH", result.toString())
+		# for result in bothResults:
+		# 	print("BOTH", result.toString())
 		return bothResults
 
 
@@ -336,17 +381,22 @@ if (__name__ == "__main__"):
 	from Config import *
 	from AWSSession import *
 
+	if len(sys.argv) < 3:
+		print("FATAL command line parameters: environment from_text_processing_folder ")
+		sys.exit()
+
+	prefix = sys.argv[2][:-1] if sys.argv[2].endswith("/") else sys.argv[2]
 	config = Config.shared()
 	lptsReader = LPTSExtractReader(config.filename_lpts_xml)
 	unicodeScript = UnicodeScript()
 	preValidate = PreValidate(lptsReader, unicodeScript)
 	config = Config.shared()
-	bucket = "dbp-etl-mass-batch"
+	bucket = "etl-development-input"
 	session = boto3.Session(profile_name = config.s3_aws_profile)
 	s3Client = session.client('s3')
 
 	testDataMap = {}
-	request = { 'Bucket': bucket, 'MaxKeys': 1000 }
+	request = { 'Bucket': bucket, 'Prefix': prefix, 'MaxKeys': 1000 }
 	hasMore = True 
 	while hasMore:
 		response = s3Client.list_objects_v2(**request)
@@ -370,9 +420,10 @@ if (__name__ == "__main__"):
 		else:
 			oneFilePath = directory + "/" + filenames[0]
 			sampleText = unicodeScript.readObject(s3Client, "s3://" + bucket, oneFilePath)
-			resultList = preValidate.validateUSXStockNo(stockNumber, filenames, sampleText)
-			for result in resultList:
-				print(result.toString())
+			stockResultList = preValidate.validateUSXStockList(stockNumber, filenames, sampleText)
+			for stockResult in stockResultList:
+				for result in stockResult:
+					print(result.toString())
 		print("ERRORS", preValidate.messages)
 		preValidate.messages = {}
 

--- a/py/dbt-etl.cfg
+++ b/py/dbt-etl.cfg
@@ -39,3 +39,4 @@ s3.artifacts_bucket = dbp-etl-artifacts-dev
 # the profile identified by s3.aws_profile must be pre-configured with permissions to assume the s3.aws_role_arn
 s3.aws_profile  = dbp-dev
 s3.aws_role_arn = arn:aws:iam::869054869504:role/dbp-etl-dev
+s3.aws_role_profile = dbp-etl-dev


### PR DESCRIPTION
It has added the feature to read stocknumber.txt and call existing methods to verify that the stocknumbers provided in the text file are actually valid.

- With the next code we can read the content of stocknumber file.
```python
if filename == 'stocknumber.txt':
	stocknumberData = s3Client.get_object(Bucket=bucket, Key=objKey)
	contents = stocknumberData['Body'].read()
	stocknumberArray = contents.decode("utf-8").splitlines()
```

- The next method is a new method to process the content of stocknumber file. 
```python
def validateUSXStockList(self, stockList, filenames, sampleText = None):
	resultList = []
	for stockListNumber in stockList:
		result = self.validateUSXStockNo(stockListNumber, filenames, sampleText)
		resultList.append(result)
	return resultList
```
### python3 load/InputFileset.py test - Local Test Execution

- python3 load/InputFileset.py test s3://etl-development-input "Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX"
```shell
Config 'test' is loaded.
Config 'test' is loaded.
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
UnicodeScript:readObject. location: s3://etl-development-input, filepath: Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/001GEN.usx

.
.
.
Download s3://etl-development-input/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/035HAB.usx to /home/vichugof/files/upload/BODNVSO_ET-usx/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/035HAB.usx
Download s3://etl-development-input/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/036ZEP.usx to /home/vichugof/files/upload/BODNVSO_ET-usx/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/036ZEP.usx
Download s3://etl-development-input/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/037HAG.usx to /home/vichugof/files/upload/BODNVSO_ET-usx/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/037HAG.usx
Download s3://etl-development-input/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/038ZEC.usx to /home/vichugof/files/upload/BODNVSO_ET-usx/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/038ZEC.usx
Download s3://etl-development-input/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/039MAL.usx to /home/vichugof/files/upload/BODNVSO_ET-usx/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/039MAL.usx
Download s3://etl-development-input/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/stocknumber.txt to /home/vichugof/files/upload/BODNVSO_ET-usx/Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/stocknumber.txt
********** Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX Tables Update failed **********
openErrorReport /home/vichugof/files/errors/Errors.out
EROR N2ADX/NVS contains a full set of books for O, but there is no damId with that scope
EROR N2BOD/NVS contains a full set of books for O, but there is no damId with that scope
EROR P2ADX/NVS contains a full set of books for N, but there is no damId with that scope
EROR P2BOD/NTV contains a full set of books for N, but there is no damId with that scope
EROR P2BOD/NTV contains a full set of books for O, but there is no damId with that scope
EROR P2BOD/NVS contains a full set of books for N, but there is no damId with that scope
Num Errors  6


```
- python3 load/InputFileset.py test s3://etl-development-input Abidji_N2ABIWBT_USX/
```shell
Config 'test' is loaded.
Config 'test' is loaded.
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
UnicodeScript:readObject. location: s3://etl-development-input, filepath: Abidji_N2ABIWBT_USX/040MAT.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/040MAT.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/040MAT.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/041MRK.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/041MRK.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/042LUK.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/042LUK.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/043JHN.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/043JHN.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/044ACT.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/044ACT.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/045ROM.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/045ROM.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0461CO.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0461CO.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0472CO.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0472CO.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/048GAL.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/048GAL.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/049EPH.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/049EPH.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/050PHP.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/050PHP.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/051COL.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/051COL.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0521TH.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0521TH.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0532TH.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0532TH.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0541TI.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0541TI.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0552TI.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0552TI.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/056TIT.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/056TIT.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/057PHM.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/057PHM.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/058HEB.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/058HEB.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/059JAS.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/059JAS.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0601PE.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0601PE.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0612PE.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0612PE.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0621JN.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0621JN.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0632JN.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0632JN.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/0643JN.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/0643JN.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/065JUD.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/065JUD.usx
Download s3://etl-development-input/Abidji_N2ABIWBT_USX/066REV.usx to /home/vichugof/files/upload/ABIWBTN_ET-usx/Abidji_N2ABIWBT_USX/066REV.usx
Database 'dbp' is opened.
Num Errors  0
```
- python3 load/InputFileset.py test s3://etl-development-input Adyghe_USX 
```shell
Config 'test' is loaded.
Config 'test' is loaded.
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
********** Adyghe_USX Tables Update failed **********
openErrorReport /home/vichugof/files/errors/Errors.out
EROR Adyghe_USX filesetId is not in LPTS
Num Errors  1
```

### python3 load/PreValidate.py tests - Local Test Execution

- python3 load/PreValidate.py test "Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX"

```shell
Config 'test' is loaded.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX
UnicodeScript:readObject. location: s3://etl-development-input, filepath: Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX/001GEN.usx
out: text/ADXNVS/ADXNVSN_ET-usx is ADXNVSN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
out: text/ADXNVS/ADXNVSO_ET-usx is ADXNVSO_ET 1, 001GEN.usx, 002EXO.usx, 003LEV.usx, 004NUM.usx, 005DEU.usx, 006JOS.usx, 007JDG.usx, 008RUT.usx, 0091SA.usx, 0102SA.usx, 0111KI.usx, 0122KI.usx, 0131CH.usx, 0142CH.usx, 015EZR.usx, 016NEH.usx, 017EST.usx, 018JOB.usx, 019PSA.usx, 020PRO.usx, 021ECC.usx, 022SNG.usx, 023ISA.usx, 024JER.usx, 025LAM.usx, 026EZK.usx, 027DAN.usx, 028HOS.usx, 029JOL.usx, 030AMO.usx, 031OBA.usx, 032JON.usx, 033MIC.usx, 034NAM.usx, 035HAB.usx, 036ZEP.usx, 037HAG.usx, 038ZEC.usx, 039MAL.usx, stocknumber.txt
out: text/KHGNTV/KHGNTVN_ET-usx is KHGNTVN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
out: text/KHGNTV/KHGNTVO_ET-usx is KHGNTVO_ET 1, 001GEN.usx, 002EXO.usx, 003LEV.usx, 004NUM.usx, 005DEU.usx, 006JOS.usx, 007JDG.usx, 008RUT.usx, 0091SA.usx, 0102SA.usx, 0111KI.usx, 0122KI.usx, 0131CH.usx, 0142CH.usx, 015EZR.usx, 016NEH.usx, 017EST.usx, 018JOB.usx, 019PSA.usx, 020PRO.usx, 021ECC.usx, 022SNG.usx, 023ISA.usx, 024JER.usx, 025LAM.usx, 026EZK.usx, 027DAN.usx, 028HOS.usx, 029JOL.usx, 030AMO.usx, 031OBA.usx, 032JON.usx, 033MIC.usx, 034NAM.usx, 035HAB.usx, 036ZEP.usx, 037HAG.usx, 038ZEC.usx, 039MAL.usx, stocknumber.txt
out: text/BODNVS/BODNVSN_ET-usx is BODNVSN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
out: text/BODNVS/BODNVSO_ET-usx is BODNVSO_ET 1, 001GEN.usx, 002EXO.usx, 003LEV.usx, 004NUM.usx, 005DEU.usx, 006JOS.usx, 007JDG.usx, 008RUT.usx, 0091SA.usx, 0102SA.usx, 0111KI.usx, 0122KI.usx, 0131CH.usx, 0142CH.usx, 015EZR.usx, 016NEH.usx, 017EST.usx, 018JOB.usx, 019PSA.usx, 020PRO.usx, 021ECC.usx, 022SNG.usx, 023ISA.usx, 024JER.usx, 025LAM.usx, 026EZK.usx, 027DAN.usx, 028HOS.usx, 029JOL.usx, 030AMO.usx, 031OBA.usx, 032JON.usx, 033MIC.usx, 034NAM.usx, 035HAB.usx, 036ZEP.usx, 037HAG.usx, 038ZEC.usx, 039MAL.usx, stocknumber.txt
ERRORS {'N2ADX/NVS': ['contains a full set of books for O, but there is no damId with that scope'], 'P2ADX/NVS': ['contains a full set of books for N, but there is no damId with that scope'], 'P2BOD/NTV': ['contains a full set of books for N, but there is no damId with that scope', 'contains a full set of books for O, but there is no damId with that scope'], 'N2BOD/NVS': ['contains a full set of books for O, but there is no damId with that scope'], 'P2BOD/NVS': ['contains a full set of books for N, but there is no damId with that scope']}
```
- python3 load/PreValidate.py test Abidji_N2ABIWBT_USX

```shell
Config 'test' is loaded.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
Abidji_N2ABIWBT_USX
UnicodeScript:readObject. location: s3://etl-development-input, filepath: Abidji_N2ABIWBT_USX/040MAT.usx
out: text/ABIWBT/ABIWBTN_ET-usx is ABIWBTN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
ERRORS {}
```

- python3 load/PreValidate.py test Aghul_P2AGXIBT_USX
```shell
Config 'test' is loaded.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
Aghul_P2AGXIBT_USX
UnicodeScript:readObject. location: s3://etl-development-input, filepath: Aghul_P2AGXIBT_USX/042LUK.usx
out: text/AGXIBT/AGXIBTP_ET-usx is AGXIBTP_ET 1, 042LUK.usx
ERRORS {}
```

- python3 load/PreValidate.py test French_N2FRN PDC PDF PDV_USX
```shell
Config 'test' is loaded.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
French_N2FRN PDC PDF PDV_USX
UnicodeScript:readObject. location: s3://etl-development-input, filepath: French_N2FRN PDC PDF PDV_USX/040MAT.usx
out: text/FRAPDVC/FRNPDCN_ET-usx is FRNPDCN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
out: text/FRAPDF/FRNPDFN_ET-usx is FRNPDFN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
out: text/FRAPDVA/FRNPDVN_ET-usx is FRNPDVN_ET 1, 040MAT.usx, 041MRK.usx, 042LUK.usx, 043JHN.usx, 044ACT.usx, 045ROM.usx, 0461CO.usx, 0472CO.usx, 048GAL.usx, 049EPH.usx, 050PHP.usx, 051COL.usx, 0521TH.usx, 0532TH.usx, 0541TI.usx, 0552TI.usx, 056TIT.usx, 057PHM.usx, 058HEB.usx, 059JAS.usx, 0601PE.usx, 0612PE.usx, 0621JN.usx, 0632JN.usx, 0643JN.usx, 065JUD.usx, 066REV.usx
ERRORS {}
```

- python3 load/PreValidate.py test ENGESVN2DA
```shell
Config 'test' is loaded.
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
ENGESVN2DA
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art/125x125
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art/1400x1400
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art/1500x1500
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art/1600x1600
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art/300x300
ERROR stock no not recognized
ERRORS {}
ENGESVN2DA/Art/50x50
ERROR stock no not recognized
ERRORS {}
```
### run DBPLoadController to process directories - Local Test Execution

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test s3://etl-development-input Abidji_N2ABIWBT_USX
```shell
********** LPTS Tables Update ok **********
Completed:  ABIWBTN_ET-usx
Completed:  ABIWBT
All Success in RunStatus
```

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test s3://etl-development-input Aghul_P2AGXIBT_USX
```shell
********** LPTS Tables Update ok **********
Completed:  AGXIBTP_ET-usx
Completed:  AGXIBT
All Success in RunStatus
```

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test s3://etl-development-input French_N2FRN PDC PDF PDV_USX
```shell
********** LPTS Tables Update ok **********
Error in RunStatus {'BIBLE': 'ok', 'LPTS': 'ok', 'French_N2FRN': 'failed', 'PDC': 'failed', 'PDF': 'failed', 'PDV_USX': 'failed'}
```

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test s3://etl-development-input "Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX"
```shell
********** LPTS Tables Update ok **********
Completed:  ADXNVSN_ET-usx
Completed:  KHGNTVN_ET-usx
Completed:  BODNVSN_ET-usx
Completed:  ADXNVS
Completed:  KHGNTV
Completed:  BODNVS
Error in RunStatus {'BIBLE': 'ok', 'LPTS': 'ok', 'ADXNVSN_ET-usx': 'ok', 'ADXNVSO_ET-usx': 'failed', 'KHGNTVN_ET-usx': 'ok', 'KHGNTVO_ET-usx': 'failed', 'BODNVSN_ET-usx': 'ok', 'BODNVSO_ET-usx': 'failed', 'Tibetan N2 & P2 ADXNVS, BODNVS, BODNTV_USX': 'failed', 'ADXNVS': 'failed', 'KHGNTV': 'failed', 'BODNVS': 'failed'}
```

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test s3://etl-development-input HYWWAVN2ET
```shell
********** HYWWAVN_ET-usx Tables Update failed **********
Database 'dbp' is opened.

Found 0 filesets to process

ERROR_06: Unable to DELETE bible_id ASESLV from bibles. It is used by table user_bookmarks.
ERROR_06: Unable to DELETE bible_id ASESLV from bibles. It is used by table user_highlights.
ERROR_06: Unable to DELETE bible_id ASESLV from bibles. It is used by table user_notes.
WARN Attempt to delete bible_id: CMDNLC when it has filesets.
WARN Attempt to delete bible_id: GRCKGV when it has filesets.
WARN Attempt to delete bible_id: NGOPBT when it has filesets.
WARN Attempt to delete bible_id: SDMGFA when it has filesets.
WARN Attempt to delete bible_id: SDMSGV when it has filesets.
WARN Attempt to delete bible_id: WRAWBV when it has filesets.
WARN Attempt to delete bible_id: WRAWPV when it has filesets.
WARN Attempt to delete bible_id: WRAWRV when it has filesets.
WARN Attempt to delete bible_id: WRAWSV when it has filesets.
ERROR_01 ISO code of bibleId unknown ??? BA1WPV
ERROR_01 ISO code of bibleId unknown bpe BPEWBV
ERROR_01 ISO code of bibleId unknown bpe BPEWPV
ERROR_01 ISO code of bibleId unknown cty CTYNLC
ERROR_01 ISO code of bibleId unknown dkg DJKNBT
ERROR_01 ISO code of bibleId unknown gef GEFSGV
ERROR_01 ISO code of bibleId unknown sdq SDQGFA
ERROR_01 ISO code of bibleId unknown suo SUOWSV
ERROR_01 ISO code of bibleId unknown uni UNIWRV
ERROR_01 ISO code of bibleId unknown xnj XNJPBT
NO INSERT, UPDATE, or DELETE Transactions to process


********** LPTS Tables Update ok **********
Error in RunStatus {'BIBLE': 'ok', 'LPTS': 'ok', 'HYWWAVN_ET-usx': 'failed'}
```

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test s3://etl-development-input ENGESVN2DA
```shell
********** ENGESVN2DA Tables Update failed **********
ERROR_06: Unable to DELETE bible_id ASESLV from bibles. It is used by table user_bookmarks.
ERROR_06: Unable to DELETE bible_id ASESLV from bibles. It is used by table user_highlights.
ERROR_06: Unable to DELETE bible_id ASESLV from bibles. It is used by table user_notes.
WARN Attempt to delete bible_id: CMDNLC when it has filesets.
WARN Attempt to delete bible_id: GRCKGV when it has filesets.
WARN Attempt to delete bible_id: NGOPBT when it has filesets.
WARN Attempt to delete bible_id: SDMGFA when it has filesets.
WARN Attempt to delete bible_id: SDMSGV when it has filesets.
WARN Attempt to delete bible_id: WRAWBV when it has filesets.
WARN Attempt to delete bible_id: WRAWPV when it has filesets.
WARN Attempt to delete bible_id: WRAWRV when it has filesets.
WARN Attempt to delete bible_id: WRAWSV when it has filesets.
ERROR_01 ISO code of bibleId unknown ??? BA1WPV
ERROR_01 ISO code of bibleId unknown bpe BPEWBV
ERROR_01 ISO code of bibleId unknown bpe BPEWPV
ERROR_01 ISO code of bibleId unknown cty CTYNLC
ERROR_01 ISO code of bibleId unknown dkg DJKNBT
ERROR_01 ISO code of bibleId unknown gef GEFSGV
ERROR_01 ISO code of bibleId unknown sdq SDQGFA
ERROR_01 ISO code of bibleId unknown suo SUOWSV
ERROR_01 ISO code of bibleId unknown uni UNIWRV
ERROR_01 ISO code of bibleId unknown xnj XNJPBT
NO INSERT, UPDATE, or DELETE Transactions to process


********** LPTS Tables Update ok **********
Error in RunStatus {'BIBLE': 'ok', 'LPTS': 'ok', 'ENGESVN2DA': 'failed'}
```

- python3 $DBP_ETL_ROOT/load/DBPLoadController.py test  s3://etl-development-input Spanish_N2SPNTLA_USX
```shell
********** LPTS Tables Update ok **********
Completed:  SPNTLAN_ET-usx
Completed:  SPNTLAO_ET-usx
Completed:  SPNTLA
Completed:  SPNTLA
All Success in RunStatus
```

