### PR TITLE
FCBHDBP-352 UpdateDBPAccessTable - access group 19x should have public domain

### DIFF
--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -61,7 +61,7 @@ class UpdateDBPAccessTable:
 				elif accessId == 181: # allow_text_DOWNLOAD
 					accessIdInLPTS = self._isPublicDomain(lptsRecord)
 				elif accessId in {191, 193}: # allow_text_APP_OFFLINE and allow_audio_APP_OFFLINE
-					accessIdInLPTS = self._isSILOnly(lptsRecord)
+					accessIdInLPTS = self._isSILOnly(lptsRecord) or self._isPublicDomain(lptsRecord)
 				else:
 					accessIdInLPTS = lpts.get(accessDesc) == "-1"
 


### PR DESCRIPTION
## Description

It has added the constraint to validate access group 19x should have public domain.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-352

## How Do I QA This

I have executed the next scripts and I got the next output.

### run DBPLoadController to process directories - Local Test Execution

- python3 load/UpdateDBPAccessTable.py test

```shell
Config 'test' is loaded.
LPTS Size. Prior: 4799, Current: 4799
LPTS Extract with 4799 records and 2500 BibleIds is loaded.
Database 'dbp' is opened.
INFO Possible Public Domain Found in N1CRK/WCV: This is a new edition of the Western Cree Bible, first published in 1862 by the British and Foreign Bible Society and revised between 1904–1908. This edition contains the revised text according to the 1976 Canadian Bible Society printing, with some updates to spelling and formatting. This text is in the public domain.
www.biblesociety.ca/
INFO Possible Public Domain Found in N1CRK/WCV: This is a new edition of the Western Cree Bible, first published in 1862 by the British and Foreign Bible Society and revised between 1904–1908. This edition contains the revised text according to the 1976 Canadian Bible Society printing, with some updates to spelling and formatting. This text is in the public domain.
www.biblesociety.ca/
INFO Possible Public Domain Found in N1CRK/WCV: This is a new edition of the Western Cree Bible, first published in 1862 by the British and Foreign Bible Society and revised between 1904–1908. This edition contains the revised text according to the 1976 Canadian Bible Society printing, with some updates to spelling and formatting. This text is in the public domain.
www.biblesociety.ca/
INFO Possible Public Domain Found in N1CRK/WCV: This is a new edition of the Western Cree Bible, first published in 1862 by the British and Foreign Bible Society and revised between 1904–1908. This edition contains the revised text according to the 1976 Canadian Bible Society printing, with some updates to spelling and formatting. This text is in the public domain.
www.biblesociety.ca/
INFO Possible Public Domain Found in N1CRK/WCV: This is a new edition of the Western Cree Bible, first published in 1862 by the British and Foreign Bible Society and revised between 1904–1908. This edition contains the revised text according to the 1976 Canadian Bible Society printing, with some updates to spelling and formatting. This text is in the public domain.
www.biblesociety.ca/
NO INSERT, UPDATE, or DELETE Transactions to process

```