### PR TITLE
FCBHDBP-358 fix dbp-etl to work in lambda

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -18,6 +18,7 @@ from LPTSExtractReader import *
 from SqliteUtility import *
 from PreValidate import *
 from AWSSession import *
+from UnicodeScript import *
 
 class InputFile:
 
@@ -65,8 +66,11 @@ class InputFileset:
 		location = sys.argv[2][:-1] if sys.argv[2].endswith("/") else sys.argv[2]
 		filesetPaths = sys.argv[3:]
 
+		unicodeScript = UnicodeScript()
+		preValidate = PreValidate(lptsReader, unicodeScript, s3Client, location)
+
 		for filesetPath in filesetPaths:
-			stocknumbers = PreValidate.getStockNumbersFromFile(filesetPath, location.replace("s3://", ""))
+			stocknumbers = preValidate.getStockNumbersFromFile(filesetPath, location.replace("s3://", ""))
 			hasStocknumbersFile = True if len(stocknumbers) > 0 else False
 			filesetPath = filesetPath[:-1] if filesetPath.endswith("/") else filesetPath
 			directory = filesetPath.split("/")[-1]

--- a/load/PreValidateHandler.py
+++ b/load/PreValidateHandler.py
@@ -1,0 +1,47 @@
+# Handler.py
+# AWS Lambda Handler for PreValidate
+import boto3
+from LPTSExtractReader import *
+from PreValidate import *
+from UnicodeScript import *
+from Config import *
+
+def handler(event, context):
+    config = Config.shared()
+    session = boto3.Session(profile_name = config.s3_aws_profile)
+    s3Client = session.client("s3")
+    bucket = event["bucket"]
+    prefix = event["prefix"]
+    unicodeScript = UnicodeScript()
+    print("Copying lpts-dbp.xml...")
+    lptsReader = LPTSExtractReader(config.filename_lpts_xml)
+    preValidate = PreValidate(lptsReader, unicodeScript, s3Client, bucket)
+
+    testDataMap = {}
+    request = { 'Bucket': bucket, 'Prefix': prefix, 'MaxKeys': 1000 }
+    hasMore = True
+    
+    while hasMore:
+        response = s3Client.list_objects_v2(**request)
+        hasMore = response['IsTruncated']
+        for item in response.get('Contents', []):
+            objKey = item.get('Key')
+            (directory, filename) = objKey.rsplit("/", 1)
+            files = testDataMap.get(directory, [])
+            files.append(filename)
+            testDataMap[directory] = files
+        if hasMore:
+            request['ContinuationToken'] = response['NextContinuationToken']
+
+    messages = []
+    for (directory, filenames) in testDataMap.items():
+        messages.append(preValidate.validateLambda(lptsReader, directory, filenames))
+    
+    print("messages: ", messages)
+    
+    return messages
+
+if (__name__ == '__main__'):
+    prefix = sys.argv[2][:-1] if sys.argv[2].endswith("/") else sys.argv[2]
+    bucket = "etl-development-input"
+    handler({"prefix": prefix, "bucket": bucket}, None)


### PR DESCRIPTION
It has changed `PreValidate` class to create a constructor that accepts the bucket and an s3Client parameters.

The load/PreValidateHandler.py class was created inside the load folder because I couldn't run it from other folder. Also, I have added the config parameter because I couldn't connect to bucket without I use my credentials.

### Run the next command:

- `python3 load/PreValidate.py test Spanish_N2SPNTLA_USX`
- `python3 load/InputFileset.py test s3://etl-development-input Spanish_N2SPNTLA_USX`
- `python3 load/DBPLoadController.py test  s3://etl-development-input Spanish_N2SPNTLA_USX`
- `python3 load/PreValidateHandler.py test Spanish_N2SPNTLA_USX`
