### PR TITLE
FCBHDBP-362 etl-web frontend needs to pass contents of stocknumber.txt to Prevalidate lambda method

### DIFF
--- a/lambda/prevalidate/Handler.py
+++ b/lambda/prevalidate/Handler.py
@@ -10,7 +10,8 @@ from PreValidate import *
 
 def handler(event, context):
 	directory = event["prefix"] # can be filesetId or lang_stockno_USX
-	filenames = event["files"] # Should be object keys   
+	filenames = event["files"] # Should be object keys
+	stocknumbersContents = event["stocknumbers"]  # Should be
 	bucket    = os.getenv("UPLOAD_BUCKET")
 
 	session = boto3.Session()
@@ -18,7 +19,7 @@ def handler(event, context):
 	print("Copying lpts-dbp.xml...")
 	s3Client.download_file(bucket, "lpts-dbp.xml", "/tmp/lpts-dbp.xml")
 	lptsReader = LPTSExtractReader("/tmp/lpts-dbp.xml")
-	
+
 	preValidate = PreValidate(lptsReader, UnicodeScript(), s3Client, bucket)
-	messages = preValidate.validateLambda(lptsReader, directory, filenames)
+	messages = preValidate.validateLambda(lptsReader, directory, filenames, stocknumbersContents)
 	return messages

--- a/lambda/prevalidate/Handler.py
+++ b/lambda/prevalidate/Handler.py
@@ -11,7 +11,11 @@ from PreValidate import *
 def handler(event, context):
 	directory = event["prefix"] # can be filesetId or lang_stockno_USX
 	filenames = event["files"] # Should be object keys
-	stocknumbersContents = event["stocknumbers"]  # Should be
+
+	# Should be a string if user has uploaded a file.
+	# e.g. "N1KANDPI\r\nO1KANDPI"
+	# each stocknumber will be separated by a line break.
+	stocknumbersContents = event["stocknumbers"]
 	bucket    = os.getenv("UPLOAD_BUCKET")
 
 	session = boto3.Session()

--- a/load/Handler.py
+++ b/load/Handler.py
@@ -11,7 +11,11 @@ from PreValidate import *
 def handler(event, context):
 	directory = event["prefix"] # can be filesetId or lang_stockno_USX
 	filenames = event["files"] # Should be object keys
-	stocknumbersContents = event["stocknumbers"]  # Should be a string if user has uploaded a file
+
+	# Should be a string if user has uploaded a file.
+	# e.g. "N1KANDPI\r\nO1KANDPI"
+	# each stocknumber will be separated by a line break.
+	stocknumbersContents = event["stocknumbers"]
 	bucket    = os.getenv("UPLOAD_BUCKET")
 
 	session = boto3.Session()

--- a/load/Handler.py
+++ b/load/Handler.py
@@ -11,6 +11,7 @@ from PreValidate import *
 def handler(event, context):
 	directory = event["prefix"] # can be filesetId or lang_stockno_USX
 	filenames = event["files"] # Should be object keys
+	stocknumbersContents = event["stocknumbers"]  # Should be a string if user has uploaded a file
 	bucket    = os.getenv("UPLOAD_BUCKET")
 
 	session = boto3.Session()
@@ -18,7 +19,6 @@ def handler(event, context):
 	print("Copying lpts-dbp.xml...")
 	s3Client.download_file(bucket, "lpts-dbp.xml", "/tmp/lpts-dbp.xml")
 	lptsReader = LPTSExtractReader("/tmp/lpts-dbp.xml")
-	
 	preValidate = PreValidate(lptsReader, UnicodeScript(), s3Client, bucket)
-	messages = preValidate.validateLambda(lptsReader, directory, filenames)
+	messages = preValidate.validateLambda(lptsReader, directory, filenames, stocknumbersContents)
 	return messages


### PR DESCRIPTION
## Description
It has updated the method `validateLambda` to accept a new parameter which is the contents of the stocknumber.txt file. If it does not exist it will be an empty.

I have updated the load/PreValidateHandlerStub.py file to add the new parameter: stocknumbers

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-362

## How Do I QA This

- You can test it if you run the next command

```shell
python3 load/PreValidateHandlerStub.py test "Kannada_N1 & O1 KANDPI_USX"
```
The above command is called without the new stocknumber parameter.

The output should be the next:

```shell
Config 'test' is loaded.
Copying lpts-dbp.xml...
LPTS Size. Prior: 4893, Current: 4893
LPTS Extract with 4893 records and 2763 BibleIds is loaded.
INFO: the following record has no stock number: EthName: Cebuano and AltName: Binisaya; Bisayan; Sebuano; Sugbuanon; Sugbuhanon; Visayan
info only (but potential error for audio and video)... N1KAN/DPI contains a full set of books for O, but there is no damId with that scope
info only (but potential error for audio and video)... O1KAN/DPI contains a full set of books for N, but there is no damId with that scope
messages:  [[]]
```

- You should test it running the next command and it will use the new stocknumber parameter:

```shell
python3 load/PreValidateHandlerStub.py test "Kannada_N1 & O1 KANDPI_USX" "N1KANDPI\r\nO1KANDPI"
```

The output should be the next:

```shell
Config 'test' is loaded.
Copying lpts-dbp.xml...
LPTS Size. Prior: 4893, Current: 4893
LPTS Extract with 4893 records and 2763 BibleIds is loaded.
INFO: the following record has no stock number: EthName: Cebuano and AltName: Binisaya; Bisayan; Sebuano; Sugbuanon; Sugbuhanon; Visayan
info only (but potential error for audio and video)... N1KAN/DPI contains a full set of books for O, but there is no damId with that scope
info only (but potential error for audio and video)... O1KAN/DPI contains a full set of books for N, but there is no damId with that scope
messages:  [[]]
```