### PR TITLE
FCBHDBP-364 ETL Stage C - implement StageCLanguageReader.getBibleIdMap

### DIFF
--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -108,7 +108,10 @@ if (__name__ == '__main__'):
 	config = Config()
 	AWSSession.shared() # ensure AWSSession init
 	db = SQLUtility(config)
-	languageReader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
+	# DATA_MODEL_MIGRATION_STAGE should be "B" or "C"
+	print("DATA_MODEL_MIGRATION_STAGE DBPLoadController ==> [%s]" % os.getenv("DATA_MODEL_MIGRATION_STAGE"))
+	migration_stage = "B" if os.getenv("DATA_MODEL_MIGRATION_STAGE") == None else os.getenv("DATA_MODEL_MIGRATION_STAGE")
+	languageReader = LanguageReaderCreator(migration_stage).create(config.filename_lpts_xml)
 	ctrl = DBPLoadController(config, db, languageReader)
 	if len(sys.argv) != 2:
 		InputFileset.validate = InputProcessor.commandLineProcessor(config, AWSSession.shared().s3Client, languageReader)

--- a/load/StageCLanguageReader.py
+++ b/load/StageCLanguageReader.py
@@ -1,7 +1,4 @@
-from unittest import result
 from LanguageReader import LanguageReaderInterface
-from SQLUtility import *
-from Config import *
 from StageCLanguageService import StageCLanguageService as LanguageService
 from StageCLanguageServiceParse import parseResult;
 
@@ -50,3 +47,6 @@ class StageCLanguageReader (LanguageReaderInterface):
             return response
 
         return None
+
+    def getFilesetRecords(self, filesetId):
+        raise Exception("Not implemented")

--- a/load/StageCLanguageRecord.py
+++ b/load/StageCLanguageRecord.py
@@ -1,6 +1,4 @@
-from Config import *
 from LanguageReader import LanguageRecordInterface
-from SQLUtility import *
 from StageCLanguageService import getMediaByIdAndFormat 
 
 class StageCLanguageRecord (LanguageRecordInterface):
@@ -77,6 +75,12 @@ class StageCLanguageRecord (LanguageRecordInterface):
 
     def Orthography(self, index):
         return self.record.get(StageCLanguageRecord.propertiesName['orthography'])
+
+    def EthName(self):
+        return self.record.get(StageCLanguageRecord.propertiesName['ethName'])
+
+    def AltName(self):
+        return self.record.get(StageCLanguageRecord.propertiesName['altName'])
 
     def Licensor(self):
         pass

--- a/load/StageCLanguageService.py
+++ b/load/StageCLanguageService.py
@@ -21,7 +21,9 @@ class StageCLanguageService:
                     fl.name,\
                     ls.statusName,\
                     md.derivativeOf,\
-                    scod.english_name AS orthography\
+                    scod.english_name AS orthography,\
+                    (select fln.name from fcbhLanguageName fln WHERE fln.languageId = fl.id and fln.type = 'ethname' limit 1) as lang_ethname,\
+                    (select fln.name from fcbhLanguageName fln WHERE fln.languageId = fl.id and fln.type = 'alternate' limit 1) as lang_alternate\
             FROM media md\
             INNER JOIN bible_media bm ON md.id = bm.mediaId\
             INNER JOIN bibleTranslation bt ON md.translationId = bt.Id\
@@ -49,7 +51,9 @@ class StageCLanguageService:
                     fl.name,\
                     ls.statusName,\
                     md.derivativeOf,\
-                    scod.english_name AS orthography\
+                    scod.english_name AS orthography,\
+                    (select fln.name from fcbhLanguageName fln WHERE fln.languageId = fl.id and fln.type = 'ethname' limit 1) as lang_ethname,\
+                    (select fln.name from fcbhLanguageName fln WHERE fln.languageId = fl.id and fln.type = 'alternate' limit 1) as lang_alternate\
             FROM media md\
             INNER JOIN bible_media bm ON md.id = bm.mediaId\
             INNER JOIN bibleTranslation bt ON md.translationId = bt.Id\
@@ -78,7 +82,9 @@ class StageCLanguageService:
                     fl.name,\
                     ls.statusName,\
                     md.derivativeOf,\
-                    scod.english_name AS orthography\
+                    scod.english_name AS orthography,\
+                    (select fln.name from fcbhLanguageName fln WHERE fln.languageId = fl.id and fln.type = 'ethname' limit 1) as lang_ethname,\
+                    (select fln.name from fcbhLanguageName fln WHERE fln.languageId = fl.id and fln.type = 'alternate' limit 1) as lang_alternate\
             FROM media md\
             INNER JOIN bible_media bm ON md.id = bm.mediaId\
             INNER JOIN bibleTranslation bt ON md.translationId = bt.Id\

--- a/load/StageCLanguageServiceParse.py
+++ b/load/StageCLanguageServiceParse.py
@@ -19,14 +19,14 @@ def parseMediaRow(rowTuple):
         LanguageRecord.propertiesName['hubText']: '',
         LanguageRecord.propertiesName['apiDevText']: '',
         LanguageRecord.propertiesName['apiDevAudio']: '',
-        LanguageRecord.propertiesName['ethName']: '',
-        LanguageRecord.propertiesName['altName']: '',
         LanguageRecord.propertiesName['webHubVideo']: '',
         LanguageRecord.propertiesName['copyrightVideo']: '',
         LanguageRecord.propertiesName['apiDevVideo']: '',
         LanguageRecord.propertiesName['status']: rowTuple[9],
         LanguageRecord.propertiesName['derivativeOf']: rowTuple[10],
         LanguageRecord.propertiesName['orthography']: rowTuple[11],
+        LanguageRecord.propertiesName['ethName']: rowTuple[12],
+        LanguageRecord.propertiesName['altName']: rowTuple[13],
     }
 
 def parseResult(result):

--- a/load/TestLanguageReaderStage.py
+++ b/load/TestLanguageReaderStage.py
@@ -1,0 +1,135 @@
+import unittest
+import os
+from LPTSExtractReader import LPTSExtractReader
+from StageCLanguageReader import StageCLanguageReader
+from Config import *
+
+class TestLanguageReaderStage(unittest.TestCase):
+    def setUp(self):
+        config = Config()
+        self.LPTSReader = LPTSExtractReader(config.filename_lpts_xml)
+        self.languageReader = StageCLanguageReader()
+
+    def assert_by_specific_media(self, stageCResult, stageBResult):
+        self.assertEqual(stageCResult.Reg_StockNumber(), stageBResult.Reg_StockNumber(), "Reg_StockNumber for N1SPAPDT should be [%s]" % stageBResult.Reg_StockNumber())
+        self.assertEqual(stageCResult.ISO(), stageBResult.ISO(), "ISO for N1SPAPDT should be [%s]" % stageBResult.ISO())
+        self.assertEqual(stageCResult.DBP_Equivalent(), stageBResult.DBP_Equivalent(), "DBP_Equivalent for N1SPAPDT should be [%s]" % stageBResult.DBP_Equivalent())
+        self.assertEqual(stageCResult.Volumne_Name(), stageBResult.Volumne_Name(), "Volumne_Name for N1SPAPDT should be [%s]" % stageBResult.Volumne_Name())
+        self.assertEqual(stageCResult.EthName(), stageBResult.EthName(), "EthName for N1SPAPDT should be [%s]" % stageBResult.EthName())
+        
+        ## For now, the next tests will be commented until the missing data in the agreements databaseìssue is solved
+
+        # self.assertEqual(stageCResult.LangName(), stageBResult.LangName(), "LangName for N1SPAPDT should be [%s]" % stageBResult.LangName())
+        # self.assertEqual(stageCResult.Country(), stageBResult.Country(), "Country for N1SPAPDT should be [%s]" % stageBResult.Country())
+        # self.assertEqual(stageCResult.DBPMobile(), stageBResult.DBPMobile(), "DBPMobile for N1SPAPDT should be [%s]" % stageBResult.DBPMobile())
+        # self.assertEqual(stageCResult.DBPWebHub(), stageBResult.DBPWebHub(), "DBPWebHub for N1SPAPDT should be [%s]" % stageBResult.DBPWebHub())
+        # self.assertEqual(stageCResult.MobileText(), stageBResult.MobileText(), "MobileText for N1SPAPDT should be [%s]" % stageBResult.MobileText())
+        # self.assertEqual(stageCResult.HubText(), stageBResult.HubText(), "HubText for N1SPAPDT should be [%s]" % stageBResult.HubText())
+        # self.assertEqual(stageCResult.APIDevText(), stageBResult.APIDevText(), "APIDevText for N1SPAPDT should be [%s]" % stageBResult.APIDevText())
+        # self.assertEqual(stageCResult.APIDevAudio(), stageBResult.APIDevAudio(), "APIDevAudio for N1SPAPDT should be [%s]" % stageBResult.APIDevAudio())
+        # self.assertEqual(stageCResult.AltName(), stageBResult.AltName(), "AltName for N1SPAPDT should be [%s]" % stageBResult.AltName())
+        # self.assertEqual(stageCResult.WebHubVideo(), stageBResult.WebHubVideo(), "WebHubVideo for N1SPAPDT should be [%s]" % stageBResult.WebHubVideo())
+        # self.assertEqual(stageCResult.Copyright_Video(), stageBResult.Copyright_Video(), "Copyright_Video for N1SPAPDT should be [%s]" % stageBResult.Copyright_Video())
+        # self.assertEqual(stageCResult.APIDevVideo(), stageBResult.APIDevVideo(), "APIDevVideo for N1SPAPDT should be [%s]" % stageBResult.APIDevVideo())
+
+    # Test the getBibleIdMap method using length of bible list
+    # @unittest.skip("skipping Total BIBLES using getBibleIdMap")
+    def test_get_bible_id_map_total_media(self):
+        listStageC = self.languageReader.getBibleIdMap()
+        listStageB = self.LPTSReader.getBibleIdMap()
+
+        self.assertEqual(len(listStageC), len(listStageB), "Total BIBLES: stage B [%s] and stage C [%s] " % (len(listStageB), len(listStageC)))
+
+    # Test the getBibleIdMap method using a specific bible
+    def test_get_bible_id_map_by_specific_bible(self):
+        listStageC = self.languageReader.getBibleIdMap()
+        listStageB = self.LPTSReader.getBibleIdMap()
+
+        self.assertEqual(len(listStageC.get('SPAPDT')), len(listStageB.get('SPAPDT')), "Total media records for the Bible ID SPAPDT Name [La Palabra de Dios para Todos]: stage B [%s] and stage C [%s]" % (len(listStageB.get('SPAPDT')), len(listStageC.get('SPAPDT'))))
+
+    def test_get_bible_id_map_by_specific_english_standard_version_bible(self):
+        listStageC = self.languageReader.getBibleIdMap()
+        listStageB = self.LPTSReader.getBibleIdMap()
+
+        self.assertEqual(len(listStageC.get('EN1ESV')), len(listStageB.get('EN1ESV')), "Total media records for the Bible ID EN1ESV Name [English Standard Version]: stage B [%s] and stage C [%s]" % (len(listStageB.get('EN1ESV')), len(listStageC.get('EN1ESV'))))
+
+    # Test the getByStockNumber method using a specific stocknumber
+    def test_get_by_stocknumber_by_specific_media(self):
+        stockNumber = 'N1SPAPDT'
+        stageBNumWithFormat = self.LPTSReader.getStocknumberWithFormat(stockNumber)
+        stageBResult = self.LPTSReader.getByStockNumber(stageBNumWithFormat)
+        stageCNumWithFormat = self.languageReader.getStocknumberWithFormat(stockNumber)
+        stageCResult = self.languageReader.getByStockNumber(stageCNumWithFormat)
+
+        self.assert_by_specific_media(stageCResult, stageBResult)
+
+    # Test the getByStockNumber method using a specific stocknumber with audio format
+    def test_get_by_stocknumber_by_specific_media_audio(self):
+        stockNumber = 'N2ACDWBT'
+        stageBNumWithFormat = self.LPTSReader.getStocknumberWithFormat(stockNumber)
+        stageBResult = self.LPTSReader.getByStockNumber(stageBNumWithFormat)
+        stageCNumWithFormat = self.languageReader.getStocknumberWithFormat(stockNumber)
+        stageCResult = self.languageReader.getByStockNumber(stageCNumWithFormat)
+
+        self.assert_by_specific_media(stageCResult, stageBResult)
+
+    # Test the getFilesetRecords10 method using a damId(media Id) value
+    def test_get_fileset_records_10(self):
+        damId = 'GNDWYIN2DA'
+        stageBResult = self.LPTSReader.getFilesetRecords10(damId)
+        stageCResult = self.languageReader.getFilesetRecords10(damId)
+
+        languageRecordB = None
+        languageRecordC = None
+
+        for (languageRecord, status, key) in stageBResult:
+            languageRecordB = languageRecord
+        for (languageRecord, status, key) in stageCResult:
+            languageRecordC = languageRecord
+        
+        self.assert_by_specific_media(languageRecordC, languageRecordB)
+
+    def printResultStageC(self, stageCResult):
+        print("")
+        print("========================== RESULT STAGE C ========================================")
+        print(stageCResult)
+        print("Reg_StockNumber: %s" % stageCResult.Reg_StockNumber())
+        print("LangName: %s" % stageCResult.LangName())
+        print("ISO: %s" % stageCResult.ISO())
+        print("Country: %s" % stageCResult.Country())
+        print("DBP_Equivalent: %s" % stageCResult.DBP_Equivalent())
+        print("Volumne_Name: %s" % stageCResult.Volumne_Name())
+
+        print("==================================================================================")
+        print("")
+
+    def printResultStageB(self, stageBResult):
+        print("")
+        print("========================== RESULT STAGE B ========================================")
+        print(stageBResult)
+        print("Reg_StockNumber: %s" % stageBResult.Reg_StockNumber())
+        print("LangName: %s" % stageBResult.LangName())
+        print("ISO: %s" % stageBResult.ISO())
+        print("Country: %s" % stageBResult.Country())
+        print("DBP_Equivalent: %s" % stageBResult.DBP_Equivalent())
+        print("Licensor: %s" % stageBResult.Licensor())
+        print("Copyrightc: %s" % stageBResult.Copyrightc())
+        print("Copyrightp: %s" % stageBResult.Copyrightp())
+        print("Volumne_Name: %s" % stageBResult.Volumne_Name())
+        print("DBPMobile: %s" % stageBResult.DBPMobile())
+        print("DBPWebHub: %s" % stageBResult.DBPWebHub())
+        print("MobileText: %s" % stageBResult.MobileText())
+        print("HubText: %s" % stageBResult.HubText())
+        print("APIDevText: %s" % stageBResult.APIDevText())
+        print("APIDevAudio: %s" % stageBResult.APIDevAudio())
+        print("EthName: %s" % stageBResult.EthName())
+        print("AltName: %s" % stageBResult.AltName())
+        print("WebHubVideo: %s" % stageBResult.WebHubVideo())
+        print("Copyright_Video: %s" % stageBResult.Copyright_Video())
+        print("APIDevVideo: %s" % stageBResult.APIDevVideo())
+
+        print("==================================================================================")
+        print("")
+
+if __name__ == '__main__':
+    unittest.main(argv=['test'], exit=False)


### PR DESCRIPTION
## Description
It has created the new file: `TestLanguageReaderStage.py` to test the different method for the stage C. It has started to test the methods: `getBibleIdMap` and `getFilesetRecords10`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-364

## How Do I QA This

- You can test it if you run the next command:

```shell
 python3 load/TestLanguageReaderStage.py test
```

Output

```shell
======================================================================
FAIL: test_get_bible_id_map_by_specific_bible (__main__.TestLanguageReaderStage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "load/TestLanguageReaderStage.py", line 48, in test_get_bible_id_map_by_specific_bible
    self.assertEqual(len(listStageC.get('SPAPDT')), len(listStageB.get('SPAPDT')), "Total media records for the Bible ID SPAPDT Name [La Palabra de Dios para Todos]: stage B [%s] and stage C [%s]" % (len(listStageB.get('SPAPDT')), len(listStageC.get('SPAPDT'))))
AssertionError: 3 != 2 : Total media records for the Bible ID SPAPDT Name [La Palabra de Dios para Todos]: stage B [2] and stage C [3]

======================================================================
FAIL: test_get_bible_id_map_by_specific_english_standard_version_bible (__main__.TestLanguageReaderStage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "load/TestLanguageReaderStage.py", line 54, in test_get_bible_id_map_by_specific_english_standard_version_bible
    self.assertEqual(len(listStageC.get('EN1ESV')), len(listStageB.get('EN1ESV')), "Total media records for the Bible ID EN1ESV Name [English Standard Version]: stage B [%s] and stage C [%s]" % (len(listStageB.get('EN1ESV')), len(listStageC.get('EN1ESV'))))
AssertionError: 5 != 2 : Total media records for the Bible ID EN1ESV Name [English Standard Version]: stage B [2] and stage C [5]

======================================================================
FAIL: test_get_bible_id_map_total_media (__main__.TestLanguageReaderStage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "load/TestLanguageReaderStage.py", line 41, in test_get_bible_id_map_total_media
    self.assertEqual(len(listStageC), len(listStageB), "Total BIBLES: stage B [%s] and stage C [%s] " % (len(listStageB), len(listStageC)))
AssertionError: 2217 != 2932 : Total BIBLES: stage B [2932] and stage C [2217] 

----------------------------------------------------------------------
Ran 6 tests in 17.121s

FAILED (failures=3)
```

According to the above tests we can see that we have difference between stage B and stage C:
1. We have difference about the amount of media records that belong to `SPAPDT` Bible.
2. We have difference about the amount of media records that belong to `EN1ESV` Bible.
3. We have difference about the total of Bibles between stage B and C.
