### PR TITLE
FCBHDBP-448 Fix increase the time out to run sofria-client

### DIFF
--- a/load/UpdateDBPTextFilesets.py
+++ b/load/UpdateDBPTextFilesets.py
@@ -73,7 +73,7 @@ class UpdateDBPTextFilesets:
 				self.config.sofria_client_js,
 				fullFilesetPath,
 				self.config.directory_accepted]
-			response = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, timeout=120)
+			response = subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, timeout=900)
 			if response == None or response.returncode != 0:
 				return((Log.EROR, "Sofria: " + str(response.stderr.decode("utf-8"))))
 			print("Sofria:", str(response.stdout.decode("utf-8")))


### PR DESCRIPTION
## Description
It has increased the time out to 15 minutes to run sofria-client process.

I have tested it on my local environment using `Spanish_N2SPNTLA_USX` folder and it is taken around `3 minutes` to complete the entire process.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-448

## How Do I QA This

- You can run the next test unit and you should get the next output:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input Spanish_N2SPNTLA_USX
```
- Output:
```shell
.
.
********** LPTS Tables Update ok **********
Completed:  SPNTLAN_ET-usx
Completed:  SPNTLAO_ET-usx
Completed:  SPNTLAN_ET
Completed:  SPNTLAN_ET-json
Completed:  SPNTLAO_ET
Completed:  SPNTLAO_ET-json
Num Errors  0
All Success in RunStatus

```
