### PR TITLE
FCBHDBP-455 Check dbp-etl issue and sofria-client

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -75,7 +75,7 @@ class InputFileset:
 		self.languageRecord = languageRecord
 		self.filesetPrefix = "%s/%s/%s" % (self.typeCode, self.bibleId, self.filesetId)
 		if self.typeCode == "text":
-			self.databasePath = "%s%s.db" % (config.directory_accepted, damId[:7] + "_" + damId[8:])
+			self.databasePath = "%s%s.db" % (config.directory_accepted, damId)
 		else:
 			self.databasePath = None
 		if self.typeCode == "text" and len(self.filesetId) < 10:
@@ -229,7 +229,7 @@ class InputFileset:
 	def fullPath(self):
 		#  This must be added to generate text_json filesets
 		if self.subTypeCode() == "text_json":
-			return "%s%s-usx-json/" % (self.config.directory_accepted, self.lptsDamId[:7] + "_" + self.lptsDamId[8:])
+			return "%s%s-json/" % (self.config.directory_accepted, self.filesetPath)
 		else:
 			if self.locationType == InputFileset.LOCAL:
 				return self.location + os.sep + self.filesetPath
@@ -434,6 +434,7 @@ if (__name__ == '__main__'):
 	Log.writeLog(config)
 
 # python3 load/InputFileset.py test s3://etl-development-input Spanish_N2SPNTLA_USX # works after refactor
+# python3 load/InputFileset.py test s3://etl-development-input ENGESVO2ET # works after refactor
 # python3 load/InputFileset.py test s3://etl-development-input ENGESVN2DA # works after refactor
 # python3 load/InputFileset.py test s3://etl-development-input SLUYPMP2DV # works after refactor
 
@@ -451,10 +452,3 @@ if (__name__ == '__main__'):
 # python3 load/InputFileset.py test s3://dbp-etl-mass-batch "Agni Sanvi N2ANYWBT/05 DBP & GBA/Agni Sanvi_N2ANYWBT/Agni Sanvi_N2ANYWBT_USX"
 # python3 load/InputFileset.py test s3://dbp-etl-mass-batch "Agta, Pahanan N2APFCMU/05 DBP & GBA/Agta, Pahanan_N2APFCMU/Agta, Pahanan_N2APFCMU_USX"
 # python3 load/InputFileset.py test s3://dbp-etl-mass-batch "Akan [AKA]/N1AKABIB (Asante)/05 DBP & GBA/Akan, Asante_N1AKABIB/Akan, Asante_N1AKABIB_USX"
-
-
-
-
-
-
-

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -241,3 +241,6 @@ if (__name__ == "__main__"):
 # python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-03-25-16-14-34 Abidji_N2ABIWxx_USX
 # python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-04-14-21-05-56 "Kannada_N1 & O1 KANDPI_USX"
 # python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-04-14-21-05-56 ENGESVN1DA
+
+# python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-03-25-16-14-34 Spanish_N2SPNTLA_USX
+# python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-09-27-13-48-13 ENGESVO2ET


### PR DESCRIPTION
# Description
It has added a fix to achieve running DBPLoadController task using ENGESVO2ET folder. It has fixed the method: fullPath to get the InputFileset fullpath value when it is of text_json type.

I have executed the DBPLoadController task and I got the following results:

```bash
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET

********** LPTS Tables Update ok **********
Completed:  ENGESVO2ET
Completed:  ENGESVO2ET
Completed:  ENGESVO2ET-json
Num Errors  0
All Success in RunStatus

***********************************************************************************************************

python3 load/DBPLoadController.py test s3://etl-development-input Abidji_N2ABIWBT_USX

********** LPTS Tables Update ok **********
Completed:  ABIWBTN_ET-usx
Completed:  ABIWBTN_ET
Completed:  ABIWBTN_ET-json
Num Errors  0
All Success in RunStatus

***********************************************************************************************************

python3 load/DBPLoadController.py test s3://etl-development-input Spanish_N2SPNTLA_USX

********** LPTS Tables Update ok **********
Completed:  SPNTLAN_ET-usx
Completed:  SPNTLAO_ET-usx
Completed:  SPNTLAN_ET
Completed:  SPNTLAN_ET-json
Completed:  SPNTLAO_ET
Completed:  SPNTLAO_ET-json
Num Errors  0
All Success in RunStatus

***********************************************************************************************************

```

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-455

## How Do I QA This
Run the DBPLoadController using the following examples:
- python3 load/DBPLoadController.py test s3://etl-development-input Spanish_N2SPNTLA_USX
- python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET
- python3 load/DBPLoadController.py test s3://etl-development-input Abidji_N2ABIWBT_USX