### PR TITLE
FCBHDBP-462 It has changed the method: getBiblePublisherVerses.

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -378,8 +378,6 @@ class InputFileset:
 
 	def numberUSXFileset(self, processedFileset):
 		# BWF 9/7/22 this assumes BiblePublisher has been called
-		# is there some renumbering that will be needed for json?
-		print("******************************************** calling numberUSXFileset. is it appropriate for text-json?")
 		if len(self.files[0].name) < 9:
 			if self.locationType == InputFileset.LOCAL:
 				directory = self.fullPath() + os.sep

--- a/load/UpdateDBPTextFilesets.py
+++ b/load/UpdateDBPTextFilesets.py
@@ -157,7 +157,8 @@ class UpdateDBPTextFilesets:
 				priorBookId = bookId
 				priorChapter = chapterNum
 				priorVerseEnd = 0
-			parts = re.split("[-,]", verseNum)
+			verseNumInput = self.removeSpecialChar(verseNum)
+			parts = re.split("[-,]", verseNumInput)
 			verseStart = self.verseString2Int(bookId, chapter, parts[0])
 			verseEnd = self.verseString2Int(bookId, chapter, parts[len(parts) -1])
 			verseText = verseText.replace('\r', '')
@@ -172,6 +173,12 @@ class UpdateDBPTextFilesets:
 		bibleDB.close()
 		return results
 
+	def removeSpecialChar(self, verse):
+		listCharacters = ['\u200f', '\u200c']
+		newVerse = verse
+		for character in listCharacters:
+			newVerse = newVerse.replace(character, '')
+		return newVerse
 
 	def verseString2Int(self, bookId, chapter, verse):
 		if verse.isdigit():


### PR DESCRIPTION
# Description
It has changed the method: `getBiblePublisherVerses`. It has added a feature to removed some special char attached to verse number to make sure that verse will be of type number.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-455

## How Do I QA This
Run the DBPLoadController using the following examples:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "Bakhtiari_P1BQIBMV_USX"

python3 load/DBPLoadController.py test s3://etl-development-input "Turkmen, Southern_P1TUKTTV_USX"

```