### PR TITLE
FCBHDBP-463 Refactor to avoid to execute BiblePublisher twice

### DIFF
--- a/load/FilenameReducer.py
+++ b/load/FilenameReducer.py
@@ -137,6 +137,7 @@ class FilenameReducer:
 			file.setSortSequence()
 
 		filename = path + os.path.basename(self.csvFilename)
+		print("FilenameReducer. Create file: ", filename)
 		with open(filename, 'w', newline='\n') as csvfile:
 			writer = csv.writer(csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
 			writer.writerow(("type_code", "bible_id", "fileset_id", "sequence", "file_name", "book_id", "book_name",

--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -58,7 +58,7 @@ class InputFileset:
 	
 
 	def __init__(self, config, location, filesetId, filesetPath, damId, typeCode, bibleId, index, languageRecord, fileList = None):
-		print("InputFileset construction. filesetId: %s" % (filesetId))
+		print("InputFileset construction. filesetId: %s location: %s" % (filesetId, location))
 		self.config = config
 		if location.startswith("s3://"):
 			self.locationType = InputFileset.BUCKET

--- a/load/S3Utility.py
+++ b/load/S3Utility.py
@@ -98,7 +98,7 @@ if (__name__ == '__main__'):
 				filePath = inp.downloadFiles()
 			else:
 				filePath = inp.fullPath()
-			errorTuple = texts.validateFileset("text_plain", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath, inp.textFilesetId())
+			errorTuple = texts.validateFileset("text_plain", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
 			if errorTuple != None:
 				logger = Log.getLogger(inp.filesetId)
 				logger.messageTuple(errorTuple)

--- a/load/Validate.py
+++ b/load/Validate.py
@@ -54,14 +54,15 @@ class Validate:
 					filePath = inp.downloadFiles()
 				else:
 					filePath = inp.fullPath()
-				for subTypeCode in ["text_plain", "text_json"]:
-					errorTuple = texts.validateFileset(subTypeCode, inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath, inp.textFilesetId())
-					if errorTuple != None:
-						logger = Log.getLogger(inp.filesetId)
-						logger.messageTuple(errorTuple)
-					else:
-						derivativeFileset = texts.createTextFileset(inp)
-						results.append(derivativeFileset)
+
+				derivativeFileset = self.validateTextPlainFilesets(texts, inp, filePath)
+
+				if derivativeFileset != None:
+					results.append(derivativeFileset)
+					derivativeJSONFileset = self.validateTextJsonFilesets(texts, inp, filePath)
+
+					if derivativeJSONFileset != None:
+						results.append(derivativeJSONFileset)
 
 		filesets += results
 
@@ -76,6 +77,33 @@ class Validate:
 		#duplicates = find.findDuplicates()
 		#find.moveDuplicates(duplicates)
 
+	def validateTextPlainFilesets(self, texts, inp, filePath):
+		errorTuple = texts.validateFileset("text_plain", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
+
+		if errorTuple == None:
+			errorTuple = texts.invokeBiblePublisher(inp, filePath)
+
+			if errorTuple == None:
+				return texts.createTextFileset(inp)
+
+		logger = Log.getLogger(inp.filesetId)
+		logger.messageTuple(errorTuple)
+
+		return None
+
+	def validateTextJsonFilesets(self, texts, inp, filePath):
+		errorTuple = texts.validateFileset("text_json", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
+
+		if errorTuple == None:
+			errorTuple = texts.invokeSofriaCli(filePath, inp.textFilesetId())
+
+			if errorTuple == None:
+				return texts.createJSONFileset(inp)
+
+		logger = Log.getLogger(inp.filesetId)
+		logger.messageTuple(errorTuple)
+
+		return None
 
 	## prepareDirectory 1. Makes sure a directory exists. 2. If it contains .csv files,
 	## they are packaged up into a zip file using the timestamp of the first csv file.


### PR DESCRIPTION
# Description
It has done a refactor to avoid to execute BiblePublisher command twice for a same fileset.

The following lines will invoke the method: validateFileset for a text_plain and this method will run BiblePublisher, if it doesn't return error, it will invoke the sofria cli. The above will void to execute BiblePublisher twice for a fileset of text type.
```python
errorTuple = texts.validateFileset("text_plain", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)

if errorTuple != None:
	logger = Log.getLogger(inp.filesetId)
	logger.messageTuple(errorTuple)
else:
	derivativeFileset = texts.createTextFileset(inp)
	results.append(derivativeFileset)

	errorTuple = texts.invokeSofriaCli(filePath, inp.textFilesetId())

	if errorTuple != None:
		logger = Log.getLogger(inp.filesetId)
		logger.messageTuple(errorTuple)
	else:
		derivativeJSONFileset = texts.createJSONFileset(inp)
		results.append(derivativeJSONFileset)
```
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-463


## How Do I QA This
Run the DBPLoadController using the following examples:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "Spanish_N2SPNTLA_USX"

```