### PR TITLE
FCBHDBP-468 UPLOADER (python) - bug loading text when directory name is filesetid

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -73,21 +73,24 @@ class InputFileset:
 		self.bibleId = bibleId
 		self.index = index
 		self.languageRecord = languageRecord
-		self.filesetPrefix = "%s/%s/%s" % (self.typeCode, self.bibleId, self.filesetId)
 		if self.typeCode == "text":
-			self.databasePath = "%s%s.db" % (config.directory_accepted, damId)
+			self.databasePath = "%s%s.db" % (config.directory_accepted, self.textFilesetId())
+			# if filesetId is of type text and it formatted as a stocknumber, we can replaced 2 peer "_".
+			self.filesetId = self.filesetId.replace("2", "_")
 		else:
 			self.databasePath = None
 		if self.typeCode == "text" and len(self.filesetId) < 10:
 			# BWF. if we encounter this error message, go upstream and change filesetId to 10 chars
 			print("*** !!! text fileset with less than 10 characters !!! ***")
-			self.csvFilename = "%s%s_%s_%s.csv" % (config.directory_accepted, self.typeCode, self.bibleId, damId[:7] + "_" + damId[8:])
+			self.csvFilename = "%s%s_%s_%s.csv" % (config.directory_accepted, self.typeCode, self.bibleId, self.textFilesetId())
 		else:
 			self.csvFilename = "%s%s_%s_%s.csv" % (config.directory_accepted, self.typeCode, self.bibleId, self.filesetId)
 		if fileList != None:
 			self.files = self._downloadSelectedFiles(fileList)
 		else:
 			self.files = self._setFilenames()
+		self.filesetPrefix = "%s/%s/%s" % (self.typeCode, self.bibleId, self.filesetId)
+
 		self.filesMap = None
 		self.mediaContainer = None
 		self.mediaCodec = None
@@ -400,7 +403,7 @@ class InputFileset:
 
 	def batchName(self):
 		if self.typeCode == "text" and len(self.filesetId) < 10:
-			return textFilesetId()
+			return self.textFilesetId()
 		else:
 			return self.filesetId
 

--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -227,9 +227,12 @@ class InputFileset:
 		else:
 			return self.location
 
+	@staticmethod
+	def transformToTextFilesetId(damId):
+		return damId[:7] + "_" + damId[8:]
 
 	def textFilesetId(self):
-		return self.lptsDamId[:7] + "_" + self.lptsDamId[8:]
+		return InputFileset.transformToTextFilesetId(self.lptsDamId)
 
 	def fullPath(self):
 		#  This must be added to generate text_json filesets
@@ -402,7 +405,10 @@ class InputFileset:
 
 
 	def batchName(self):
-		if self.typeCode == "text" and len(self.filesetId) < 10:
+		if self.typeCode == "text":
+			if len(self.filesetId) < 10:
+				print ("DEBUG: text filesetid less than 10 characters long: " + self.filesetId)
+
 			return self.textFilesetId()
 		else:
 			return self.filesetId
@@ -431,8 +437,8 @@ if (__name__ == '__main__'):
 				if file.name.endswith(".usx"):
 					bibleDB.execute("INSERT INTO tableContents (code) VALUES (?)", (file.name.split(".")[0],))
 			inp.numberUSXFileset(inp)
-		#print(inp.toString())
-		#print("subtype", inp.subTypeCode())
+		# print(inp.toString())
+		# print("subtype", inp.subTypeCode())
 	Log.writeLog(config)
 
 # python3 load/InputFileset.py test s3://etl-development-input Spanish_N2SPNTLA_USX # works after refactor

--- a/load/InputProcessor.py
+++ b/load/InputProcessor.py
@@ -40,7 +40,7 @@ class InputProcessor:
 			for data in dataList:
 				inp = InputFileset(config, location, data.filesetId, path, data.damId, 
 					data.typeCode, data.bibleId(), data.index, data.languageRecord, data.fileList)
-				#print("INPUT", inp.toString())
+				# print("INPUT", inp.toString())
 				results.append(inp)
 			if messages != None and len(messages) > 0:
 				print("Validate.filesetCommandLineParser...setting RunStatus to fail for fileset %s because validate returned messages %s" % (directory, messages))

--- a/load/LPTSExtractReader.py
+++ b/load/LPTSExtractReader.py
@@ -8,6 +8,7 @@ import sys
 import os
 from xml.dom import minidom
 from LanguageReader import LanguageReaderInterface, LanguageRecordInterface
+from InputFileset import *
 
 class LPTSExtractReader (LanguageReaderInterface):
 
@@ -190,7 +191,7 @@ class LPTSExtractReader (LanguageReaderInterface):
 					self.filesetIdMap[damId] = statuses
 					if "Text" in key: # Put in second key for Text filesets with underscore
 						damId = record[key]
-						damId = damId[:7] + "_" + damId[8:]
+						damId = InputFileset.transformToTextFilesetId(damId)
 						statuses = self.filesetIdMap.get(damId, [])
 						statuses.append((status, languageRecord))
 						self.filesetIdMap[damId] = statuses
@@ -418,7 +419,7 @@ class LanguageRecord (LanguageRecordInterface):
 	def ReduceTextList(self, damIdList):
 		damIdSet = set()
 		for (damId, index, status, fieldName) in damIdList:
-			damIdOut = damId[:7] + "_" + damId[8:]
+			damIdOut = InputFileset.transformToTextFilesetId(damId)
 			damIdSet.add((damIdOut, index, status))
 		return damIdSet
 

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -70,9 +70,6 @@ class PreValidate:
 		return (resultList, self.messages)
 
 
-	def parseFilesetIdFromDirectoryName(self, directory):
-		return directory[:7] + "_" + directory[8:] + "-usx" if directory[8:10] == "ET" else directory
-
 	## Validate filesetId and return PreValidateResult
 	def validateFilesetId(self, directoryName):
 		filesetId = directoryName


### PR DESCRIPTION
## Description
It has updated the InputFileset class to change the filesetid when it is of type text and it formatted as a stocknumber. It will replace 2 peer '_'. E.g. fix to change the filesetid to be `ENGESVO_ET` when it is `ENGESVO2ET`.

We have done a similar logic that has been created into the `PreValidate` class, method: `validateFilesetId`. You can see it in the following line:
https://github.com/faithcomesbyhearing/dbp-etl/blob/master/load/PreValidate.py#L80

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-468

## How Do I QA This
Run the DBPLoadController using the following examples:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "Spanish_N2SPNTLA_USX"

output:

BIBLE=ok, LPTS=ok, SPNTLAN_ET-usx=ok, SPNTLAO_ET-usx=ok, SPNTLAN_ET=ok, SPNTLAN_ET-json=ok, SPNTLAO_ET=ok, SPNTLAO_ET-json=ok

```

```shell
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET

output:

BIBLE=ok, LPTS=ok, ENGESVO_ET=ok, ENGESVO_ET-json=ok

```