### PR TITLE
FCBHDBP-468 UPLOADER (python) - bug loading text when directory name is filesetid

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -227,12 +227,8 @@ class InputFileset:
 		else:
 			return self.location
 
-	@staticmethod
-	def transformToTextFilesetId(damId):
-		return damId[:7] + "_" + damId[8:]
-
 	def textFilesetId(self):
-		return InputFileset.transformToTextFilesetId(self.lptsDamId)
+		return LanguageRecordInterface.transformToTextFilesetId(self.lptsDamId)
 
 	def fullPath(self):
 		#  This must be added to generate text_json filesets

--- a/load/LPTSExtractReader.py
+++ b/load/LPTSExtractReader.py
@@ -8,7 +8,6 @@ import sys
 import os
 from xml.dom import minidom
 from LanguageReader import LanguageReaderInterface, LanguageRecordInterface
-from InputFileset import *
 
 class LPTSExtractReader (LanguageReaderInterface):
 
@@ -191,7 +190,7 @@ class LPTSExtractReader (LanguageReaderInterface):
 					self.filesetIdMap[damId] = statuses
 					if "Text" in key: # Put in second key for Text filesets with underscore
 						damId = record[key]
-						damId = InputFileset.transformToTextFilesetId(damId)
+						damId = LanguageRecordInterface.transformToTextFilesetId(damId)
 						statuses = self.filesetIdMap.get(damId, [])
 						statuses.append((status, languageRecord))
 						self.filesetIdMap[damId] = statuses
@@ -419,7 +418,7 @@ class LanguageRecord (LanguageRecordInterface):
 	def ReduceTextList(self, damIdList):
 		damIdSet = set()
 		for (damId, index, status, fieldName) in damIdList:
-			damIdOut = InputFileset.transformToTextFilesetId(damId)
+			damIdOut = LanguageRecordInterface.transformToTextFilesetId(damId)
 			damIdSet.add((damIdOut, index, status))
 		return damIdSet
 

--- a/load/LanguageReader.py
+++ b/load/LanguageReader.py
@@ -82,6 +82,9 @@ class LanguageRecordInterface(ABC):
     def Copyrightc():
         pass
 
+    @staticmethod
+    def transformToTextFilesetId(damId):
+        return damId[:7] + "_" + damId[8:]
 
     ## BWF - part of LanguageRecord interface. may be a common base class method
     def ReduceTextList(self, damIdList):


### PR DESCRIPTION
## Description
Hotfix. It has moved the method: `transformToTextFilesetId` to `LanguageReader` class.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-468

## How Do I QA This
Run the lambda handler in dev.