### PR TITLE
FCBHDBP-468 Hotfix - UPLOADER (python) - bug loading text when directory name is filesetid

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -102,11 +102,14 @@ class InputFileset:
 		results = []
 		results.append("InputFileset\n")
 		results.append("location=" + self.location + "\n")
+		results.append("filesetPath=" + self.filesetPath + "\n")
+		results.append("fullPath=" + self.fullPath() + "\n")
 		results.append("locationType=" + self.locationType)
 		results.append("prefix=%s/%s/%s" % (self.typeCode, self.bibleId, self.filesetId))
 		results.append(" damId=" + self.lptsDamId)
 		results.append(" stockNum=" + self.stockNum())
 		results.append(" index=" + str(self.index))
+		results.append(" subTypeCode=" + str(self.subTypeCode()))
 		results.append(" script=" + str(self.languageRecord.Orthography(self.index)) + "\n")
 		results.append("filesetPrefix=" + self.filesetPrefix + "\n")
 		results.append("csvFilename=" + self.csvFilename + "\n")
@@ -230,19 +233,10 @@ class InputFileset:
 	def textFilesetId(self):
 		return LanguageRecordInterface.transformToTextFilesetId(self.lptsDamId)
 
-	# note: this is only used for InputFileset.LOCAL
 	def fullPath(self):
-		# if self.subTypeCode() == "text_json":
-		# 	return "%s%s-json/" % (self.config.directory_accepted, self.textFilesetId())
-		# else:
-		# 	if self.locationType == InputFileset.LOCAL:
-		# 		return self.location + os.sep + self.filesetPath
-		# 	else:
-		# 		return self.location + "/" + self.filesetPath
 		if self.locationType == InputFileset.LOCAL:
 			return self.location + os.sep + self.filesetPath
 		else:
-			# make sure the filesetPath contains -json (or whatever)
 			return self.location + "/" + self.filesetPath
 
 
@@ -411,9 +405,7 @@ class InputFileset:
 			if len(self.filesetId) < 10:
 				print ("DEBUG: text filesetid less than 10 characters long: " + self.filesetId)
 
-			return self.textFilesetId()
-		else:
-			return self.filesetId
+		return self.filesetId
 
 
 if (__name__ == '__main__'):
@@ -439,8 +431,8 @@ if (__name__ == '__main__'):
 				if file.name.endswith(".usx"):
 					bibleDB.execute("INSERT INTO tableContents (code) VALUES (?)", (file.name.split(".")[0],))
 			inp.numberUSXFileset(inp)
-		# print(inp.toString())
-		# print("subtype", inp.subTypeCode())
+		print(inp.toString())
+		print("subtype", inp.subTypeCode())
 	Log.writeLog(config)
 
 # python3 load/InputFileset.py test s3://etl-development-input Spanish_N2SPNTLA_USX # works after refactor

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -96,9 +96,10 @@ class PreValidate:
 				media = "audio"
 			elif "Text" in fieldName:
 				media = "text"	
-				# for the case when text (which is usx) is loaded from a directory containing the filesetid:
-				# we know the text is actually usx, so here is where we want to change the filesetid to include the suffix -usx
-				# FIXME: add -usx to filesetid, but only if not already present		
+				# for the case when text (which is usx) is loaded from a directory containing the filesetid,
+				# we know the text is actually usx, so, we should make sure that filesetid includes the suffix -usx
+				if not filesetId.endswith("-usx"):
+					filesetId = filesetId + "-usx"
 			elif "Video" in fieldName:
 				media = "video"
 			else:

--- a/load/UpdateDBPTextFilesets.py
+++ b/load/UpdateDBPTextFilesets.py
@@ -49,7 +49,11 @@ class UpdateDBPTextFilesets:
 		elif subTypeCode == "text_html":
 			self.newFilesetId = filesetId.split("-")[0] + "-html"
 		elif subTypeCode == "text_json":
-			self.newFilesetId = filesetId.split("-")[0] + "-json"	
+			self.newFilesetId = filesetId.split("-")[0] + "-json"
+			self.newFilesetPath = self.newFilesetId
+			self.newLocation = self.config.directory_accepted
+		elif subTypeCode == "text_usx":
+			self.newFilesetId = filesetId.split("-")[0] + "-usx"
 
 		return None
 
@@ -106,7 +110,7 @@ class UpdateDBPTextFilesets:
 	
 	def createJSONFileset(self, inputFileset):
 		inp = inputFileset
-		textFileset = InputFileset(self.config, inp.location, self.newFilesetId, inp.filesetPath, inp.lptsDamId, inp.typeCode, inp.bibleId, inp.index, inp.languageRecord)
+		textFileset = InputFileset(self.config, self.newLocation, self.newFilesetId, self.newFilesetPath, inp.lptsDamId, inp.typeCode, inp.bibleId, inp.index, inp.languageRecord)
 		return textFileset
 
 


### PR DESCRIPTION
## Description
It has fixed an issue to avoid to run twice the text plain fileset and to avoid to overlook adding the usx fileset to the list.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-468

## How Do I QA This
Run the DBPLoadController using the following examples:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "Spanish_N2SPNTLA_USX"

output:
BIBLE=ok, LPTS=ok, SPNTLAN_ET-usx=ok, SPNTLAO_ET-usx=ok, SPNTLAN_ET=ok, SPNTLAN_ET-json=ok, SPNTLAO_ET=ok, SPNTLAO_ET-json=ok
```

```shell
python3 load/DBPLoadController.py test s3://etl-development-input ENGWEBN2ET

output:
BIBLE=ok, LPTS=ok, ENGWEBN_ET=ok, ENGWEBN_ET-usx=ok, ENGWEBN_ET-json=ok
```

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "Turkmen, Southern_P1TUKTTV_USX"

output:
BIBLE=ok, LPTS=ok, TUKTTVP_ET-usx=ok, TUKTTVP_ET=ok, TUKTTVP_ET-json=ok
```

```shell
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET

output:
BIBLE=ok, LPTS=ok, ENGESVO_ET=ok, ENGESVO_ET-usx=ok, ENGESVO_ET-json=ok
```