### PR TITLE
FCBHDBP-369 uploader (python) - Update language_translation table with alternate language name(s)

### DIFF
--- a/load/LPTSExtractReader.py
+++ b/load/LPTSExtractReader.py
@@ -429,6 +429,15 @@ class LanguageRecord (LanguageRecordInterface):
 			return None
 		else:
 			return result
+	def AltNameList(self):
+		altNametext = self.AltName()
+
+		if altNametext != None:
+			altNamelist = altNametext.split("|")
+			listStripped = map(lambda altName: altName.strip(), altNamelist)
+			return list(listStripped)
+
+		return []
 
 	def APIDevAudio(self):
 		return self.record.get("APIDevAudio")
@@ -579,7 +588,7 @@ class LanguageRecord (LanguageRecordInterface):
 		return self.record.get("Gideon_Text_Excluded")
 
 	def HeartName(self):
-		return self.record.get("HeartName")
+		return self.record.get("HeartName").strip() if self.record.get("HeartName") != None else None
 
 	def HubText(self):
 		return self.record.get("HubText")

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -46,8 +46,8 @@ class UpdateDBPLPTSTable:
 		self.updateBibleFilesetCopyrightOrganizations(filesetList)
 		bibletranslations = UpdateDBPBibleTranslations(self.config, self.db, self.dbOut, self.languageReader)
 		bibletranslations.insertEngVolumeName()
-		# languageTranslations = UpdateDBPLanguageTranslation(self.config, self.db, self.dbOut, self.languageReader)
-		# languageTranslations.updateOrInsertlanguageTranslation()
+		languageTranslations = UpdateDBPLanguageTranslation(self.config, self.db, self.dbOut, self.languageReader)
+		languageTranslations.updateOrInsertlanguageTranslation()
 		self.db.close()
 
 	##

--- a/load/UpdateDBPLanguageTranslation.py
+++ b/load/UpdateDBPLanguageTranslation.py
@@ -8,90 +8,101 @@ from SQLUtility import *
 from SQLBatchExec import *
 
 class UpdateDBPLanguageTranslation:
+    HEART_NAME_PRIORITY = 9
+    ALT_NAME_PRIORITY = 0
+    LANGUAGE_UNDETERMINED_TRANSLATION_ID = 8012
+
     def __init__(self, config, db, dbOut, languageReader):
         self.config = config
         self.db = db
         self.dbOut = dbOut
         self.languageReader = languageReader
+        self.langProcessed = {}
 
     def updateOrInsertlanguageTranslation(self):
         return self.process()
 
     def process(self):
         bibles = self.languageReader.getBibleIdMap()
-        langProcessed = {}
 
         for bibleId in bibles:
-            for index, languageRecord in bibles.get(bibleId):
+            for _, languageRecord in bibles.get(bibleId):
                 lang = self.languageId(bibleId, languageRecord)
-                insertRows = []
-                updateRows = []
 
                 if lang != None:
                     if languageRecord.HeartName() != None:
-                        languageSourceId = lang
-                        languageTranslationId = lang
-                        languageName = languageRecord.HeartName()
-                    else:
-                        languageSourceId = lang
-                        languageTranslationId = 6414
-                        languageName = languageRecord.AltName()
+                        self._processLanguageWithHeartName(lang, languageRecord)
 
-                if languageName != None and langProcessed.get(lang) == None:
-                    # store an index to avoid to process twice the same record
-                    langProcessed[lang] = True
-                    languageName = languageName.replace("'", "\\'")
-                    # The column name that belongs to language_translations entity is a varchar with limit of 80 characters
-                    languageName = languageName[:80]
-                    langExistsByNameAndId = self.getTranslationByLangNameIdAndPriority(languageName, languageSourceId, languageTranslationId, 9)
+                    if languageRecord.AltName() != None:
+                        self._processLanguageWithAltName(lang, languageRecord)
 
-                    # Validate if the translation already exists
-                    if langExistsByNameAndId == None:
-                        translationIdWithSameLangAndPriority = self.getTranslationByLangIdAndPriority(languageSourceId, languageTranslationId, 9)
-                        translationIdWithSameLangAndName = self.getTranslationByLangName(languageName, languageSourceId, languageTranslationId)
-
-                        tableName = "language_translations"
-
-                        # if it exists a translation record with the same Id and same priority but with different name
-                        # and it also exists a other translation record with the same name and the same Id
-                        if translationIdWithSameLangAndPriority != None and translationIdWithSameLangAndName != None:
-                            attrNames = ("priority",)
-                            pkeyNames = ("language_source_id", "language_translation_id", "priority")
-                            updateRows.append((0, languageSourceId, languageTranslationId, 9))
-                            self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
-
-                            updateRows = []
-                            attrNames = ("priority",)
-                            pkeyNames = ("language_source_id", "language_translation_id", "name")
-                            updateRows.append((9, languageSourceId, languageTranslationId, languageName))
-                            self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
-                        elif translationIdWithSameLangAndPriority != None:
-                            attrNames = ("name",)
-                            pkeyNames = ("language_source_id", "language_translation_id", "priority", "id")
-                            updateRows.append((languageName, languageSourceId, languageTranslationId, 9, translationIdWithSameLangAndPriority))
-                            self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
-                        elif translationIdWithSameLangAndName != None:
-                            attrNames = ("name", "priority")
-                            pkeyNames = ("language_source_id", "language_translation_id", "id")
-                            updateRows.append((languageName, 9, languageSourceId, languageTranslationId, translationIdWithSameLangAndName))
-                            self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
-                        else:
-                            attrNames = ("name", "priority")
-                            pkeyNames = ("language_source_id", "language_translation_id")
-                            insertRows.append((languageName, 9, languageSourceId, languageTranslationId))
-                            self.dbOut.insert(tableName, pkeyNames, attrNames, insertRows)
         return True
+
+    def _processLanguageWithHeartName(self, languageSourceId, languageRecord):
+        heartNamePriority = self.HEART_NAME_PRIORITY
+        languageTranslationId = languageSourceId
+        languageNames = [languageRecord.HeartName()]
+        self._updateOrInsertLanguageTranslations(languageNames, languageSourceId, languageTranslationId, heartNamePriority)
+
+    def _processLanguageWithAltName(self, languageSourceId, languageRecord):
+        altNamePriority = self.ALT_NAME_PRIORITY
+        languageTranslationId = self.LANGUAGE_UNDETERMINED_TRANSLATION_ID
+        languageNames = languageRecord.AltNameList()
+        self._updateOrInsertLanguageTranslations(languageNames, languageSourceId, languageTranslationId, altNamePriority)
+
+    def _updateOrInsertLanguageTranslations(self, languageNames, languageSourceId, languageTranslationId, priority):
+        for languageName in languageNames:
+            insertRows = []
+            updateRows = []
+
+            indexedKey = "%s%s%s" % (languageSourceId,languageName,priority)
+
+            if (languageName != None and
+                languageName != "" and not
+                self._isPejorativeAltName(languageName) and
+                self.langProcessed.get(indexedKey) == None):
+
+                # store an index to avoid to process twice the same record
+                self.langProcessed[indexedKey] = True
+                # The column name that belongs to language_translations entity is a varchar with limit of 80 characters
+                languageName = languageName[:80]
+
+                translationIdWithSameLangAndName = self.getTranslationByLangName(languageName, languageSourceId, languageTranslationId)
+
+                tableName = "language_translations"
+
+                if translationIdWithSameLangAndName != None:
+                    langExistsByNameAndId = self.getTranslationByLangNameIdAndPriority(languageName, languageSourceId, languageTranslationId, priority)
+
+                    if langExistsByNameAndId == None:
+                        languageName = languageName.replace("'", "\\'")
+                        attrNames = ("priority",)
+                        pkeyNames = ("language_source_id", "language_translation_id", "name", "id")
+                        updateRows.append((priority, languageSourceId, languageTranslationId, languageName, translationIdWithSameLangAndName))
+                        self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
+                else:
+                    languageName = languageName.replace("'", "\\'")
+                    attrNames = ("name", "priority")
+                    pkeyNames = ("language_source_id", "language_translation_id")
+                    insertRows.append((languageName, priority, languageSourceId, languageTranslationId))
+                    self.dbOut.insert(tableName, pkeyNames, attrNames, insertRows)
+
+    def _isPejorativeAltName(self, languageName):
+        return languageName.find("(pej") != -1
 
     def languageId(self, bibleId, bible):
         result = None
         if bible != None:
             iso = bible.ISO()
             langName = bible.LangName()
-            result = self.db.selectScalar("SELECT id FROM languages WHERE iso=%s AND name=%s", (iso, langName))
-            if result != None:
-                return result
-        else:
-            iso = bibleId[:3].lower()
+
+            if iso != None and langName != None:
+                result = self.db.selectScalar("SELECT id FROM languages WHERE iso=%s AND name=%s", (iso, langName))
+                if result != None:
+                    return result
+
+        iso = bibleId[:3].lower()
+
         result = self.db.selectScalar("SELECT id FROM languages WHERE iso=%s", (iso))
         if result != None:
             return result
@@ -102,10 +113,10 @@ class UpdateDBPLanguageTranslation:
         return self.db.selectScalar("SELECT id FROM language_translations WHERE language_source_id=%s AND language_translation_id = %s AND priority=%s LIMIT 1", (languageSourceId, languageTranslationId, priority))
 
     def getTranslationByLangName(self, name, languageSourceId, languageTranslationId):
-        return self.db.selectScalar("SELECT id FROM language_translations WHERE language_source_id=%s AND language_translation_id = %s AND name=%s LIMIT 1", (languageSourceId, languageTranslationId, name))
+        return self.db.selectScalar("SELECT id FROM language_translations WHERE language_source_id=%s AND language_translation_id = %s AND BINARY name=%s LIMIT 1", (languageSourceId, languageTranslationId, name))
 
     def getTranslationByLangNameIdAndPriority(self, name, languageSourceId, languageTranslationId, priority):
-        return self.db.selectScalar("SELECT id FROM language_translations WHERE language_source_id=%s AND language_translation_id = %s AND name=%s AND priority=%s LIMIT 1", (languageSourceId, languageTranslationId, name, priority))
+        return self.db.selectScalar("SELECT id FROM language_translations WHERE language_source_id=%s AND language_translation_id = %s AND BINARY name=%s AND priority=%s LIMIT 1", (languageSourceId, languageTranslationId, name, priority))
 
 ## Unit Test
 if (__name__ == '__main__'):


### PR DESCRIPTION
## Description
It has updated UpdateDBPLanguageTranslation to get the alternate name. But the altName is string with multple values that are delimited peer '|' and it must split the string into multiple altName records to create a insert statement for each altName.

## NOTE
We need to validate with Alan if the generated statement sqls  are correct. You can see the first version of the statement sql in the following URL: https://fullstacklabs.atlassian.net/browse/FCBHDBP-369?focusedCommentId=112606
 
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-369

## How Do I QA This

- You can test it if you run the next command:

```shell
 python3 load/UpdateDBPLanguageTranslation.py test
```
