### PR TITLE
FCBHDBP-469 UPLOADER (python) - recognize five character stocknumbers

### DIFF
--- a/load/TextStockNumberProcessor.py
+++ b/load/TextStockNumberProcessor.py
@@ -185,7 +185,10 @@ class TextStockNumberProcessor:
 
 		if len(stockNumberArray) > 0:
 			for stockNumberItem in stockNumberArray:
-				stockNumberArrayFinal.append(stockNumberItem[:-3] + "/" + stockNumberItem[-3:])
+				if len(stockNumberItem) > 7:
+					stockNumberArrayFinal.append(stockNumberItem[:-3] + "/" + stockNumberItem[-3:])
+				else:
+					stockNumberArrayFinal.append(stockNumberItem)
 
 		return stockNumberArrayFinal	
 


### PR DESCRIPTION
# Description
It has updated the Prevalidate validation to allow looking for stocknumbers with less than 8 characters.

## NOTE
I have updated the validation to allow looking for stocknumbers less than 7 characters. The above because I have saw that we have stocknumbers with length equals to 5 e.g. `C2WEB`, length = 6 e.g. `C2NIRV` and length = 7 e.g. `C2EKIDZ`

This PR depends on the following PR.
- https://github.com/faithcomesbyhearing/dbp-etl/pull/85
 
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-369?focusedCommentId=112653

## How Do I QA This

```shell
## Run Prevalidate
python3 load/PreValidate.py test s3://etl-development-input "" English_C2WEB_USX B

## Run Validate
python3 load/Validate.py test s3://etl-development-input English_C2WEB_USX

## Run LoadController
python3 load/DBPLoadController.py test s3://etl-development-input English_C2WEB_USX
```
