### PR TITLE
FCBHDBP-478 Uploader (python) Associate "ND" stocknumbers to "ND" Damids

### DIFF
--- a/load/LPTSExtractReader.py
+++ b/load/LPTSExtractReader.py
@@ -266,6 +266,42 @@ class LPTSExtractReader (LanguageReaderInterface):
 
 class LanguageRecord (LanguageRecordInterface):
 
+	Reg_StockNumberDamIdIndex = {
+		"Reg_CAudioDAMID1": True,
+		"Reg_NTAudioDamID1": True,
+		"Reg_OTAudioDamID1": True,
+		"Reg_CAudioDamID2": True,
+		"Reg_NTAudioDamID2": True,
+		"Reg_OTAudioDamID2": True,
+		"Reg_CAudioDamID3": True,
+		"Reg_NTAudioDamID3": True,
+		"Reg_OTAudioDamID3": True,
+		"Reg_NTTextDamID1": True,
+		"Reg_OTTextDamID1": True,
+		"Reg_NTTextDamID2": True,
+		"Reg_OTTextDamID2": True,
+		"Reg_NTTextDamID3": True,
+		"Reg_OTTextDamID3": True
+	}
+
+	ND_StockNumberDamIdIndex = {
+		"ND_CAudioDAMID1":  True,
+		"ND_NTAudioDamID1": True,
+		"ND_OTAudioDamID1": True,
+		"ND_CAudioDamID2":  True,
+		"ND_NTAudioDamID2": True,
+		"ND_OTAudioDamID2": True,
+		"ND_CAudioDamID3":  True,
+		"ND_NTAudioDamID3": True,
+		"ND_OTAudioDamID3": True,
+		"ND_NTTextDamID1":  True,
+		"ND_OTTextDamID1":  True,
+		"ND_NTTextDamID2":  True,
+		"ND_OTTextDamID2":  True,
+		"ND_NTTextDamID3":  True,
+		"ND_OTTextDamID3":  True
+	}
+
 	audio1DamIdDict = {
 		"ND_CAudioDAMID1": 		"ND_CAudioDAMStatus",
 		"ND_NTAudioDamID1": 	"ND_NTAudioDamIDStatus1",
@@ -628,7 +664,13 @@ class LanguageRecord (LanguageRecordInterface):
 		return self.record.get("ND_Recording_Status")
 
 	def ND_StockNumber(self):
-		return self.record.get("ND_StockNumber")
+		result = self.record.get("ND_StockNumber")
+		result = result.strip()
+
+		if result == "none":
+			result = None
+
+		return result
 
 	def NTAudioDamLoad(self):
 		return self.record.get("NTAudioDamLoad")
@@ -683,6 +725,26 @@ class LanguageRecord (LanguageRecordInterface):
 
 	def Reg_StockNumber(self):
 		return self.record.get("Reg_StockNumber")
+
+	def StockNumberByFilesetIdAndType(self, filesetId, typeCode):
+		damIds = self.DamIdList(typeCode)
+		for (damId, _, _, fieldname) in damIds:
+			if filesetId == damId:
+				if LanguageRecord.ND_StockNumberDamIdIndex.get(fieldname) == True:
+					return self.ND_StockNumber()
+				elif LanguageRecord.Reg_StockNumberDamIdIndex.get(fieldname) == True:
+					return self.Reg_StockNumber()
+		return None
+
+	def StockNumberByFilesetId(self, filesetId):
+		for typeCode in {"audio", "text", "video"}:
+			stockNumber = self.StockNumberByFilesetIdAndType(
+				LanguageRecordInterface.GetFilesetIdLen10(filesetId),
+				typeCode
+			)
+			if stockNumber != None:
+				return stockNumber
+		return None
 
 	def Restrictions(self):
 		return self.record.get("Restrictions")
@@ -827,13 +889,28 @@ if (__name__ == '__main__'):
 	result = {}
 	config = Config()
 	reader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
+	stockNumber = None
+	if len(sys.argv) > 2:
+		stockNumber = sys.argv[2]
+
 	for rec in reader.resultSet:
 		textDamIds = rec.DamIdList("text")
-		textDamIds = rec.ReduceTextList(textDamIds)
+		reduceTextDamIds = rec.ReduceTextList(textDamIds)
 		#if len(textDamIds) > 1:
 		#	print(textDamIds)
-		listDamIds = list(textDamIds)
+		listDamIds = list(reduceTextDamIds)
 		if len(listDamIds) > 1 and listDamIds[0][0][:6] != listDamIds[1][0][:6]:
 			print(rec.Reg_StockNumber(), listDamIds)
 
+		if stockNumber == rec.Reg_StockNumber() or stockNumber == rec.ND_StockNumber():
+			audioDamIds = rec.DamIdList("audio")
+			print("")
+			print("=========================================", stockNumber, "=========================================")
+			print("Reg_StockNumber:", rec.Reg_StockNumber())
+			print("ND_StockNumber:", rec.ND_StockNumber())
+			print("Text DamIds:", textDamIds)
+			print("Audio DamIds:", audioDamIds)
+			print("ReduceText DamIds:", reduceTextDamIds)
+			print("=========================================", stockNumber, "=========================================")
+			print("")
 

--- a/load/LanguageReader.py
+++ b/load/LanguageReader.py
@@ -86,6 +86,10 @@ class LanguageRecordInterface(ABC):
     def transformToTextFilesetId(damId):
         return damId[:7] + "_" + damId[8:]
 
+    @staticmethod
+    def GetFilesetIdLen10(filesetId):
+        return filesetId[:10]
+
     ## BWF - part of LanguageRecord interface. may be a common base class method
     def ReduceTextList(self, damIdList):
         pass    

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -120,7 +120,8 @@ class UpdateDBPLPTSTable:
 						elif name == "bitrate":
 							description = bitrate
 						elif name == "stock_no":
-							description = languageRecord.Reg_StockNumber()
+							stockNumber = languageRecord.StockNumberByFilesetId(dbpFilesetId)
+							description = stockNumber if stockNumber != None else languageRecord.Reg_StockNumber()
 						elif name == "volume":
 							description = languageRecord.Volumne_Name()
 						else:
@@ -140,7 +141,7 @@ class UpdateDBPLPTSTable:
 					elif (oldDescription != description):
 						description = description.replace("'", "\\'")
 						updateRows.append((description, adminOnly, notes, iso, hashId, name, languageId))
-						#print("UPDATE: %s %s: OLD %s  NEW: %s" % (filesetId, name, oldDescription, description))
+						# print("UPDATE: filesetId=%s hashId=%s %s: OLD %s  NEW: %s" % (filesetId, hashId, name, oldDescription, description))
 
 		tableName = "bible_fileset_tags"
 		pkeyNames = ("hash_id", "name", "language_id")
@@ -330,6 +331,9 @@ class UpdateDBPLPTSTable:
 
 
 if (__name__ == '__main__'):
+	from Config import *
+	from LanguageReaderCreator import *
+
 	config = Config()
 	languageReader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
 	dbOut = SQLBatchExec(config)
@@ -337,7 +341,7 @@ if (__name__ == '__main__'):
 	filesets.process()
 	dbOut.displayStatements()
 	dbOut.displayCounts()
-	#dbOut.execute("test-lpts")
+	dbOut.execute("test-lpts")
 
 
 # python3 load/UpdateDBPLPTSTable.py test


### PR DESCRIPTION
# Description
It has changed the logic to associate ND stocknumbers to ND Damids in UpdateDBPLPTSTable class. For now on, it will try to match the stocknumber to the filsetid by first checking if the filesetid belongs to a ND Stocknumber or a Reg Stocknumber.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-478

## How Do I QA This

```shell
## Run
python3 load/UpdateDBPLPTSTable.py test
```


```shell
## Output
Config 'test' is loaded.
migration stage: [B]
LPTS Size. Prior: 5105, Current: 5105
LPTS Extract with 5105 records and 3030 BibleIds is loaded.
Database 'dbp_2022_03_18' is opened.
********* BEGIN LPTS UPDATE *********  2.3 sec
......
......
UPDATE bible_fileset_tags SET description='N1ZYP/WBT', admin_only='0', notes=NULL, iso='eng' WHERE hash_id='6daff755ae7d' AND name='stock_no' AND language_id='6414';
update bible_fileset_tags 1703
```

## Outcome
1. I have tested these changes on my local environment and I saw the following updates statements for the CJO/WBT example:
```sql
# 787ece11fb9f = CJOWBTN1DA
UPDATE bible_fileset_tags SET description='N1CJO/WBT', admin_only='0', notes=NULL, iso='eng' WHERE hash_id='787ece11fb9f' AND name='stock_no' AND language_id='6414';
# 6944dd64c83d = CJOWBTN1DA-opus16
UPDATE bible_fileset_tags SET description='N1CJO/WBT', admin_only='0', notes=NULL, iso='eng' WHERE hash_id='6944dd64c83d' AND name='stock_no' AND language_id='6414';
# 77a3ce499c11 = CJOWBTN1DA16
UPDATE bible_fileset_tags SET description='N1CJO/WBT', admin_only='0', notes=NULL, iso='eng' WHERE hash_id='77a3ce499c11' AND name='stock_no' AND language_id='6414';
# b54e57a27419 = CJOWBTN1SA
UPDATE bible_fileset_tags SET description='N1CJO/WBT', admin_only='0', notes=NULL, iso='eng' WHERE hash_id='b54e57a27419' AND name='stock_no' AND language_id='6414';
```

2. I have tested these changes on my local environment and after when I executed the following sql query:
```sql
select stocknumber, filesetid, hash_id, type FROM bible_fileset_lookup where type LIKE "audio%" AND SUBSTRING(stocknumber,2,1) <> SUBSTRING(filesetid,8,1);
```
I got 4 rows:
| stocknumber  | filesetid | hash_id | type |
| ------------ | ---------- | ------- | ---- |
| O1ARB/VDV	| ARBVDVO2DA	    | a9ab8acdaf46	| audio_drama |
| O1ARB/VDV	| ARBVDVO2DA-opus16	| 26b0ed0d1790	| audio_drama |
| N2ZPO/TBL	| ZPOTBLN1DA	    | 97dcbe624b3d	| audio |
| N2ZPO/TBL	| ZPOTBLN1DA-opus16	| 2cba1f0f2b3f	| audio |

But, I think it is ok because I have checked the lpts-dbp.xml and I saw that the above filesets are associated with Reg_ prefix stocknumbers and therefore we might need to update the lpts-dbp.xml.

E.g.

```xml
#ARBVDVO2DA
<Reg_StockNumber>O1ARB/VDV</Reg_StockNumber>
...
<ND_StockNumber> none</ND_StockNumber>
...
<Reg_OTTextDamID1>ARBVDVO2ET</Reg_OTTextDamID1>
<Reg_OTTextDamIDStatus1>Live</Reg_OTTextDamIDStatus1>
<Reg_OTAudioDamID1>ARBVDVO2DA</Reg_OTAudioDamID1>
```
```xml
#ZPOTBLN1DA
<Reg_StockNumber>N2ZPO/TBL</Reg_StockNumber>
....
<ND_StockNumber>N1ZPO/TBL</ND_StockNumber>
....
<Reg_NTTextDamID1>ZPOTBLN1ET</Reg_NTTextDamID1>
<Reg_NTTextDamIDStatus1>Live</Reg_NTTextDamIDStatus1>
<Reg_NTAudioDamID1>ZPOTBLN1DA</Reg_NTAudioDamID1>
<Reg_NTAudioDamIDStatus1>Live</Reg_NTAudioDamIDStatus1>
```
3. You can see the complete outcome in the following link: [log_update_stocknumber_final.log](https://github.com/faithcomesbyhearing/dbp-etl/files/9974352/log_update_stocknumber_final.log)
