### PR TITLE
FCBHDBP-486 

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -74,15 +74,15 @@ class InputFileset:
 		self.index = index
 		self.languageRecord = languageRecord
 		if self.typeCode == "text":
-			self.databasePath = "%s%s.db" % (config.directory_accepted, self.textFilesetId())
-			# if filesetId is of type text and it formatted as a stocknumber, we can replaced 2 peer "_".
-			self.filesetId = self.filesetId.replace("2", "_")
+			self.databasePath = "%s%s.db" % (config.directory_accepted, self.textLptsDamId())
+			# if filesetId is of type text and it formatted as a stocknumber, we can replaced 2 or 1 peer "_".
+			self.filesetId = self.textFilesetId()
 		else:
 			self.databasePath = None
 		if self.typeCode == "text" and len(self.filesetId) < 10:
 			# BWF. if we encounter this error message, go upstream and change filesetId to 10 chars
 			print("*** !!! text fileset with less than 10 characters !!! ***")
-			self.csvFilename = "%s%s_%s_%s.csv" % (config.directory_accepted, self.typeCode, self.bibleId, self.textFilesetId())
+			self.csvFilename = "%s%s_%s_%s.csv" % (config.directory_accepted, self.typeCode, self.bibleId, self.textLptsDamId())
 		else:
 			self.csvFilename = "%s%s_%s_%s.csv" % (config.directory_accepted, self.typeCode, self.bibleId, self.filesetId)
 		if fileList != None:
@@ -231,7 +231,10 @@ class InputFileset:
 			return self.location
 
 	def textFilesetId(self):
-		return LanguageRecordInterface.transformToTextFilesetId(self.lptsDamId)
+		return LanguageRecordInterface.transformToTextId(self.filesetId)
+
+	def textLptsDamId(self):
+		return LanguageRecordInterface.transformToTextId(self.lptsDamId)
 
 	def fullPath(self):
 		if self.locationType == InputFileset.LOCAL:

--- a/load/LPTSExtractReader.py
+++ b/load/LPTSExtractReader.py
@@ -190,7 +190,7 @@ class LPTSExtractReader (LanguageReaderInterface):
 					self.filesetIdMap[damId] = statuses
 					if "Text" in key: # Put in second key for Text filesets with underscore
 						damId = record[key]
-						damId = LanguageRecordInterface.transformToTextFilesetId(damId)
+						damId = LanguageRecordInterface.transformToTextId(damId)
 						statuses = self.filesetIdMap.get(damId, [])
 						statuses.append((status, languageRecord))
 						self.filesetIdMap[damId] = statuses
@@ -454,7 +454,7 @@ class LanguageRecord (LanguageRecordInterface):
 	def ReduceTextList(self, damIdList):
 		damIdSet = set()
 		for (damId, index, status, fieldName) in damIdList:
-			damIdOut = LanguageRecordInterface.transformToTextFilesetId(damId)
+			damIdOut = LanguageRecordInterface.transformToTextId(damId)
 			damIdSet.add((damIdOut, index, status))
 		return damIdSet
 

--- a/load/LanguageReader.py
+++ b/load/LanguageReader.py
@@ -82,9 +82,14 @@ class LanguageRecordInterface(ABC):
     def Copyrightc():
         pass
 
+    # Transform a damId or filesetId to a text damId or a text filesetId. e.g.
+    # from filesetId: TNKWBTN1ET-json to text filesetId: TNKWBTN_ET-json
+    # from filesetId: TNKWBTN1ET-usx to text filesetId: TNKWBTN_ET-usx
+    #
+    # from damId: TNKWBTN1ET to text damId: TNKWBTN_ET
     @staticmethod
-    def transformToTextFilesetId(damId):
-        return damId[:7] + "_" + damId[8:]
+    def transformToTextId(id):
+        return id[:7] + "_" + id[8:]
 
     @staticmethod
     def GetFilesetIdLen10(filesetId):

--- a/load/Validate.py
+++ b/load/Validate.py
@@ -95,7 +95,7 @@ class Validate:
 		errorTuple = texts.validateFileset("text_json", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
 
 		if errorTuple == None:
-			errorTuple = texts.invokeSofriaCli(filePath, inp.textFilesetId())
+			errorTuple = texts.invokeSofriaCli(filePath, inp.textLptsDamId())
 
 			if errorTuple == None:
 				return texts.createJSONFileset(inp)


### PR DESCRIPTION
# Description
It has fixed an issue related to the text fileset TNKWBTN1ET. The issue was related because it is not transforming the filesetId to text filesetId when fileset contains number 1 rather 2. So, I have created a new method called `textLptsDamId` to transform the damId to text damId (e.g. `from TNKWBTN1ET to TNKWBTN_ET`) and the old method `textFilesetId` will transform the filesetId to a text textFilesetId (e.g.` from TNKWBTN1ET-json to TNKWBTN_ET-json`). 

Then, we have renamed to method: transformToTextFilesetId to transformToTextId because the above method should be used to transform the filesetId (e.g TNKWBTN1ET-json) or the damId (TNKWBTN1ET) and so, this method should be used for both case.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-486

## NOTE
@bradflood I have tested using the latest lpts-dbp.xml file and it has threw the following error related with the folder: ENGESVO2ET

```shell
Validate.filesetCommandLineParser...setting RunStatus to fail for fileset ENGESVO2ET because validate returned messages {'ENGESVO2ET-usx': ['LPTS O2ESV field _x0031_Orthography is required.']}
```
But, I have tested with an old version of lpts-dbp.xml and it worked.

## How Do I QA This

```shell
## Run
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET
python3 load/DBPLoadController.py test s3://etl-development-input "Turkmen, Southern_P1TUKTTV_USX"
python3 load/DBPLoadController.py test s3://etl-development-input TNKWBTN1ET
python3 load/DBPLoadController.py test s3://etl-development-input "Bakhtiari_P1BQIBMV_USX"
python3 load/DBPLoadController.py test s3://etl-development-input "English_C2WEB_USX"
python3 load/DBPLoadController.py test s3://etl-development-input "Spanish_N2SPNTLA_USX"
python3 load/DBPLoadController.py test s3://etl-development-input "Spanish_N1SPAPBT_USX"

```
## outcome
![screenshot-dev uploader biblebrain com-2022 11 14-18_31_25](https://user-images.githubusercontent.com/73488660/201789664-09cd2d1f-31f8-45f7-97dc-7e57ad53b314.png)

