### PR TITLE
FCBHDBP-496 updater (python) - upsert EthName into language_translation with priority = 5

### DIFF
--- a/load/LPTSExtractReader.py
+++ b/load/LPTSExtractReader.py
@@ -619,7 +619,7 @@ class LanguageRecord (LanguageRecordInterface):
 			return None
 
 	def EthName(self):
-		return self.record.get("EthName")
+		return self.record.get("EthName").strip() if self.record.get("EthName") != None else None 
 
 	def FairUseLimit(self):
 		return self.record.get("FairUseLimit")

--- a/load/UpdateDBPLanguageTranslation.py
+++ b/load/UpdateDBPLanguageTranslation.py
@@ -10,6 +10,7 @@ from SQLBatchExec import *
 class UpdateDBPLanguageTranslation:
     HIGH_PRIORITY = 9
     ALT_NAME_PRIORITY = 0
+    ETHNOLOGUE_NAME_PRIORITY = 5
     LANGUAGE_UNDETERMINED_TRANSLATION_ID = 8012
     LANGUAGE_ENGLISH_ID = 6414
 
@@ -34,6 +35,9 @@ class UpdateDBPLanguageTranslation:
 
                 if languageRecord.AltName() != None:
                     self._processLanguageWithAltName(lang, languageRecord)
+
+                if languageRecord.EthName() != None:
+                    self._processLanguageEthName(lang, languageRecord)
 
         return True
 
@@ -60,6 +64,12 @@ class UpdateDBPLanguageTranslation:
         languageTranslationId = self.LANGUAGE_UNDETERMINED_TRANSLATION_ID
         languageNames = languageRecord.AltNameList()
         self._updateOrInsertLangTranslationsLowerPriority(languageNames, languageSourceId, languageTranslationId, altNamePriority)
+
+    def _processLanguageEthName(self, languageSourceId, languageRecord):
+        ethNamePriority = self.ETHNOLOGUE_NAME_PRIORITY
+        languageTranslationId = self.LANGUAGE_UNDETERMINED_TRANSLATION_ID
+        languageNames = [languageRecord.EthName()]
+        self._updateOrInsertLangTranslationsLowerPriority(languageNames, languageSourceId, languageTranslationId, ethNamePriority)
 
     def _updateOrInsertLangTranslationsLowerPriority(self, languageNames, languageSourceId, languageTranslationId, priority):
         for languageName in languageNames:


### PR DESCRIPTION
## Description
It has updated the class: `UpdateDBPLanguageTranslation` to add the feature to insert or update a language_translations record according to the EthName value. The priority for EthName record will be 5.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-496

## How Do I QA This
- I have executed the following command on my local environment:

```shell
python3 load/UpdateDBPLanguageTranslation.py test
```
- and I got the following outcome:
[log_update_languages_translation_ethame.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10117730/log_update_languages_translation_ethame.log)

