### PR TITLE
FCBHDBP-504 Update UpdateDBPLanguageTranslation class to avoid create insert/update sql strings for the same unique key

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -498,7 +498,7 @@ class FilenameParser:
 		print("\nFound %s filesets to process" % (len(filesets)))
 		for inp in filesets:
 			prefix = inp.filesetPrefix
-			print(prefix)
+			print("FilenameParser: %s typeCode: %s" % (prefix, inp.typeCode))
 			logger = Log.getLogger(inp.filesetId)
 			if inp.typeCode == "audio":
 				templates = self.audioTemplates
@@ -538,7 +538,7 @@ class FilenameParser:
 				(extraChapters, missingChapters, missingVerses) = self.checkVideoBookChapterVerse(prefix, files)
 			elif inp.typeCode == "text":
 				(extraChapters, missingChapters, missingVerses) = ([], [], [])
-			
+
 			reducer = FilenameReducer(self.config, prefix, inp.csvFilename, files, extraChapters, missingChapters, missingVerses)
 			reducer.process(logger)
 		print("")

--- a/load/TextStockNumberProcessor.py
+++ b/load/TextStockNumberProcessor.py
@@ -150,7 +150,7 @@ class TextStockNumberProcessor:
 				if result == None:
 					self.errors.append("text is script %s, but there is no damId with that script in scope P." % (actualScript,))
 			else:
-				self.errorMessage("contains some books with scope [%s], but there is no damId with scope P" % (scope))
+				self.errors.append("contains some books with scope [%s], but there is no damId with scope P" % (scope))
 
 		return result
 

--- a/load/UpdateDBPTextFilesets.py
+++ b/load/UpdateDBPTextFilesets.py
@@ -57,8 +57,7 @@ class UpdateDBPTextFilesets:
 
 		return None
 
-
-	def invokeSofriaCli(self, fullFilesetPath, inputFileset):
+	def invokeSofriaCli(self, fullFilesetPath, inputFilesetDBPath, inputFilesetId):
 		# invoke sofria
 		#
 		# This is the invocation of the sofria-cli.
@@ -76,8 +75,8 @@ class UpdateDBPTextFilesets:
 			self.config.sofria_client_js,
 			"run",
 			fullFilesetPath,
-			"--populate-db=%s" % (inputFileset.databasePath),
-			"--generate-json=%s" % (os.path.join(self.config.directory_accepted, inputFileset.filesetId))]
+			"--populate-db=%s" % (inputFilesetDBPath),
+			"--generate-json=%s" % (os.path.join(self.config.directory_accepted, inputFilesetId))]
 		print("================= Invoke Sofria Cli ========================")
 		print("cmd: ", cmd)
 		print("============================================================")

--- a/load/Validate.py
+++ b/load/Validate.py
@@ -55,20 +55,22 @@ class Validate:
 				else:
 					filePath = inp.fullPath()
 
-				textplainFileset = self.validateTextPlainFilesets(texts, inp, filePath)
-
-				if textplainFileset != None:
+				if self.validateTextPlainFilesets(texts, inp, filePath) == True:
+					textplainFileset = texts.createTextFileset(inp)
 					results.append(textplainFileset)
-					jsonFileset = self.validateTextJsonFilesets(texts, inp, filePath)
 
-					if jsonFileset != None:
-						results.append(jsonFileset)
+					if self.validateTextJsonFilesets(texts, inp, filePath) == True:
 
-						errorTuple = texts.invokeSofriaCli(filePath, jsonFileset)
+						inputFilesetDBPath = "%s%s.db" % (self.config.directory_accepted, inp.textLptsDamId())
+						inputFilesetId = texts.newFilesetId
+						errorTuple = texts.invokeSofriaCli(filePath, inputFilesetDBPath, inputFilesetId)
 
 						if errorTuple != None:
 							logger = Log.getLogger(inp.filesetId)
 							logger.messageTuple(errorTuple)
+
+						jsonFileset = texts.createJSONFileset(inp)
+						results.append(jsonFileset)
 
 		filesets += results
 
@@ -87,23 +89,24 @@ class Validate:
 		errorTuple = texts.validateFileset("text_plain", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
 
 		if errorTuple == None:
-			return texts.createTextFileset(inp)
+			return True
 
 		logger = Log.getLogger(inp.filesetId)
 		logger.messageTuple(errorTuple)
 
-		return None
+		# return None
+		return False
 
 	def validateTextJsonFilesets(self, texts, inp, filePath):
 		errorTuple = texts.validateFileset("text_json", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
 
 		if errorTuple == None:
-			return texts.createJSONFileset(inp)
+			return True
 
 		logger = Log.getLogger(inp.filesetId)
 		logger.messageTuple(errorTuple)
 
-		return None
+		return False
 
 	## prepareDirectory 1. Makes sure a directory exists. 2. If it contains .csv files,
 	## they are packaged up into a zip file using the timestamp of the first csv file.


### PR DESCRIPTION
## Description
It has update `load/UpdateDBPLanguageTranslation.py` class be examining a running list of the keys to avoid to create insert/update sql strings for the same unique key.

Also, it has changed the way to invoke `sofria-client`, for now on, it will invoke the `sofria-client` before it creates JSON input fileset because the we need to create the JSON files before that it creates the  JSON input fileset.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-504

## How Do I QA This
- I have executed the following command on my local environment to load "North Karelian_N1KRLIBT_USX":
```shell
python3 load/DBPLoadController.py test s3://etl-development-input "North Karelian_N1KRLIBT_USX"
```

The above command returned the following outcome:
[North Karelian_N1KRLIBT_USX.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10192182/North.Karelian_N1KRLIBT_USX.log)

- I have executed the following command on my local environment to update Language Translations entity:

```shell
python3 load/UpdateDBPLanguageTranslation.py test
```
And I got the following outcome:
[log_update_languages_translation.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10192185/log_update_languages_translation.log)
