### PR TITLE
FCBHDBP-509 and FCBHDBP-511 uploader (python) - failed to insert records into access_group_filesets for ENGNKJ% in prod - uploader (python) - remove code that deletes from access_group_filesets

### DIFF
--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -28,6 +28,7 @@ class UpdateDBPAccessTable:
 		textAccessTypes = self.db.select("SELECT id, name, lpts_fieldname FROM access_groups WHERE name like %s", ("%text%",))
 		videoAccessTypes = self.db.select("SELECT id, name, lpts_fieldname FROM access_groups WHERE name like %s", ("%video%",))
 		for (bibleId, filesetId, setTypeCode, setSizeCode, assetId, hashId) in filesetList:
+
 			#print(bibleId, filesetId, setTypeCode, setSizeCode, assetId, hashId)
 			typeCode = setTypeCode.split("_")[0]
 			if filesetId[8:10] == "SA":
@@ -51,6 +52,8 @@ class UpdateDBPAccessTable:
 				lpts = languageRecord.record
 			else:
 				lpts = {}
+				print ("getLanguageRecord method did not return a record for typeCode: %s, bibleId: %s, dbpFilesetId: %s " % ( typeCode, bibleId, dbpFilesetId))
+
 
 			for (accessId, accessName, accessDesc) in accessTypes:
 				accessIdInDBP = accessId in dbpAccessSet;
@@ -70,7 +73,7 @@ class UpdateDBPAccessTable:
 				if accessIdInLPTS and not accessIdInDBP:
 					insertRows.append((hashId, accessId))
 				elif accessIdInDBP and not accessIdInLPTS:
-					deleteRows.append((hashId, accessId))
+					print("accessId not in DBP or LPTS, but not deleting.. accessId: %s hashId: %s" % (accessId, hashId))
 
 		tableName = "access_group_filesets"
 		pkeyNames = ("hash_id", "access_group_id")


### PR DESCRIPTION
## Description
It has added a message to notify that the `languageRecord` object related to fileset has NOT been found. The above can be related to status value stored into lpts.xml file. Also, It has removed the logic to delete the access permissions but it has added a message to warn that access permissions will not be deleted.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-509
https://fullstacklabs.atlassian.net/browse/FCBHDBP-511

## How Do I QA This
- I have executed the following command on my local environment:
```shell
python3 load/UpdateDBPAccessTable.py test
```

- outcome
[log_update_DBP_access_table.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10249784/log_update_DBP_access_table.log)

