### PR TITLE
FCBHDBP-515 enable non-integer verse identifier

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -212,6 +212,15 @@ class Filename:
 	def print(self):
 		print(self.bookSeq, self.fileSeq, self.bookId, self.chapter, self.name, self.damid, self.type, self.file, self.errors)
 
+	def toString(self):
+		print(
+		"bookSeq: %s, fileSeq: %s, bookId: %s, chapter: %s, verseStart: %s, verseStartNum: %s, name: %s, damid: %s, type: %s, file: %s, errors: %s" % (
+			self.bookSeq, self.fileSeq, self.bookId,
+			self.chapter, self.verseStart, self.verseStartNum,
+			self.name, self.damid, self.type,
+			self.file, self.errors
+		))
+
 
 class FilenameRegex:
 

--- a/load/FilenameReducer.py
+++ b/load/FilenameReducer.py
@@ -141,14 +141,14 @@ class FilenameReducer:
 		with open(filename, 'w', newline='\n') as csvfile:
 			writer = csv.writer(csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
 			writer.writerow(("type_code", "bible_id", "fileset_id", "sequence", "file_name", "book_id", "book_name",
-				"chapter_start", "chapter_end", "verse_start", "verse_end", "datetime", "file_size", "errors"))
+				"chapter_start", "chapter_end", "verse_start", "verse_sequence", "verse_end", "datetime", "file_size", "errors"))
 			## prefix and some fields are redundant
 			## optional: bookSeq, fileSeq, name, title, usfx2, damid, filetype
 			(typeCode, bibleId, filesetId) = self.filePrefix.split("/")
 			for file in sorted(fileList, key=attrgetter('sortSequence')):
 				writer.writerow((typeCode, bibleId, filesetId, file.getSequence(), 
 					file.file, file.bookId, file.name, file.chapter, file.chapterEnd, 
-					file.verseStart, file.verseEnd, file.datetime, file.length, 
+					file.verseStart, file.verseStartNum, file.verseEnd, file.datetime, file.length,
 					"; ".join(file.errors)))
 		DBPRunFilesS3.uploadParsedCSV(self.config, filename)
 

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -219,7 +219,9 @@ class UpdateDBPFilesetTables:
 					(chapterStart, verseStart, verseEnd) = self.convertChapterStart(bookId)
 				else:
 					chapterStart = int(row["chapter_start"]) if row["chapter_start"] != "" else None
-					verseStart = int(row["verse_start"]) if row["verse_start"] != "" else 1
+					verseStart = row["verse_start"] if row["verse_start"] != "" else 1
+					verseSequence = int(row["verse_sequence"]) if row["verse_sequence"] != 0 or row["verse_sequence"] != "" else 1
+
 					verseEnd = int(row["verse_end"]) if row["verse_end"] != "" else None
 				chapterEnd = int(row["chapter_end"]) if row["chapter_end"] != "" else None
 				fileName = row["file_name"]
@@ -233,7 +235,7 @@ class UpdateDBPFilesetTables:
 				key = (bookId, chapterStart, verseStart)
 				dbpValue = dbpMap.get(key)
 				if dbpValue == None:
-					insertRows.append((chapterEnd, verseEnd, fileName, fileSize, duration,
+					insertRows.append((chapterEnd, verseEnd, fileName, fileSize, duration, verseSequence,
 						hashId, bookId, chapterStart, verseStart))
 				else:
 					del dbpMap[key]
@@ -243,7 +245,7 @@ class UpdateDBPFilesetTables:
 						fileName != dbpFileName or
 						fileSize != dbpFileSize or
 						duration != dbpDuration):
-						updateRows.append((chapterEnd, verseEnd, fileName, fileSize, duration,
+						updateRows.append((chapterEnd, verseEnd, fileName, fileSize, duration, verseSequence,
 						hashId, bookId, chapterStart, verseStart))
 
 		if inp.typeCode == "video":
@@ -252,7 +254,7 @@ class UpdateDBPFilesetTables:
 
 		tableName = "bible_files"
 		pkeyNames = ("hash_id", "book_id", "chapter_start", "verse_start")
-		attrNames = ("chapter_end", "verse_end", "file_name", "file_size", "duration")
+		attrNames = ("chapter_end", "verse_end", "file_name", "file_size", "duration", "verse_sequence")
 		self.dbOut.insert(tableName, pkeyNames, attrNames, insertRows, 2)
 		self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
 		self.dbOut.delete(tableName, pkeyNames, deleteRows)

--- a/load/UpdateDBPLanguageTranslation.py
+++ b/load/UpdateDBPLanguageTranslation.py
@@ -138,7 +138,17 @@ class UpdateDBPLanguageTranslation:
                         languageTranslationId
                     )
 
-                    if rowOldEthName != None:
+                    if rowOldEthName != None and rowlangNoEthName != None:
+                        (langIdNoEthName, oldLangPriority) = rowlangNoEthName
+                        pkeyNames = ("language_source_id", "language_translation_id", "id")
+                        valuesToUpdate = [("priority", priority, oldLangPriority, languageSourceId, languageTranslationId, langIdNoEthName)]
+                        self.dbOut.updateCol(tableName, pkeyNames, valuesToUpdate)
+
+                        (langExistsByPriorityAndId, _) = rowOldEthName
+                        pkeyNames = ("language_source_id", "language_translation_id", "id")
+                        updateRows = [("priority", 0, priority, languageSourceId, languageTranslationId, langExistsByPriorityAndId)]
+                        self.dbOut.updateCol(tableName, pkeyNames, updateRows)
+                    elif rowOldEthName != None:
                         (langExistsByPriorityAndId, oldLangTranName) = rowOldEthName
                         pkeyNames = ("language_source_id", "language_translation_id", "priority", "id")
                         valuesToUpdate = [("name", languageName, oldLangTranName, languageSourceId, languageTranslationId, priority, langExistsByPriorityAndId)]

--- a/py/BibleFileTimestamps_Insert.py
+++ b/py/BibleFileTimestamps_Insert.py
@@ -99,11 +99,12 @@ class BibleFileTimestamps_Insert:
 							timing = round(float(result.group(1)), 2)
 							verseStart = int(result.group(3))
 							versePart = result.group(4)
+							verseSequence = verseStart
 							if versePart == "" or versePart == "a":
-								values.append((fileId, verseStart, None, timing))
+								values.append((fileId, verseStart + versePart, None, timing, verseSequence))
 								# check that all verses are included
 								if (priorVerse + 1) != verseStart:
-									print("WARNING: %s %s:%s skipped from %d to %d" % (filesetId, book, chapter, priorVerse, verseStart))
+									print("WARNING: %s %s:%s skipped from %d to %d" % (filesetId, book, chapter, priorVerse, verseStart + versePart))
 								priorVerse = verseStart
 					else:
 						print("ERROR: No file for %s %s:%s" % (filesetId, book, chapter))
@@ -117,7 +118,7 @@ class BibleFileTimestamps_Insert:
 			" WHERE bf.hash_id = bs.hash_id AND bs.id = %s)")
 		errorStmt = ("REPLACE INTO bible_fileset_tags (hash_id, name, description, admin_only, iso, language_id)"
 			" VALUES (%s, 'timing_est_err', %s, 0, 'eng', 6414)")
-		insertStmt = "INSERT INTO bible_file_timestamps (bible_file_id, verse_start, verse_end, `timestamp`) VALUES (%s, %s, %s, %s)"		
+		insertStmt = "INSERT INTO bible_file_timestamps (bible_file_id, verse_start, verse_end, `timestamp`, verse_sequence) VALUES (%s, %s, %s, %s, %s)"
 		print("Row %d to be inserted for %s, %s" % (len(values), bibleDir, filesetId))
 		cursor = self.db.conn.cursor()
 		try:


### PR DESCRIPTION
## Description
The verse_start column has been changed from an integer type to a string type because sometimes a verse is represented as a string, such as '3a'. As a result, we have updated the verse_start column for the following entities: bible_verses, bible_files and bible_file_timestamps. Then, we have created a new column called verse_sequence of type integer for each above entity. As a result, we have replaced the column verse_start with verse_sequence in order to sort the records.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-515


## How Do I QA This
- I have executed the following command on my local environment:
```shell
- python3 load/DBPLoadController.py test s3://etl-development-input BMUPNGN2ET
## outcome
BIBLE=ok, LPTS=ok, BMUPNGP_ET-usx=ok, BMUPNGP_ET=ok, BMUPNGP_ET-json=ok

- python3 load/DBPLoadController.py test s3://etl-development-input TNTLAIN2ET
## outcome 
BIBLE=ok, LPTS=ok, TNTLAIN_ET-usx=ok, TNTLAIN_ET=ok, TNTLAIN_ET-json=ok

- python3 load/DBPLoadController.py test s3://etl-development-input TXQWYIN1ET
## outcome
BIBLE=ok, LPTS=ok, TXQWYIN_ET-usx=ok, TXQWYIN_ET=ok, TXQWYIN_ET-json=ok

```