### PR TITLE
FCBHDBP-515 enable non-integer verse identifier - DBP-ETL

### DIFF
--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -221,8 +221,8 @@ class UpdateDBPFilesetTables:
 					chapterStart = int(row["chapter_start"]) if row["chapter_start"] != "" else None
 					verseStart = row["verse_start"] if row["verse_start"] != "" else 1
 					verseSequence = int(row["verse_sequence"]) if row["verse_sequence"] != 0 or row["verse_sequence"] != "" else 1
+					verseEnd = row["verse_end"] if row["verse_end"] != "" else None
 
-					verseEnd = int(row["verse_end"]) if row["verse_end"] != "" else None
 				chapterEnd = int(row["chapter_end"]) if row["chapter_end"] != "" else None
 				fileName = row["file_name"]
 				if inp.typeCode == "video":

--- a/load/UpdateDBPTextFilesets.py
+++ b/load/UpdateDBPTextFilesets.py
@@ -182,7 +182,8 @@ class UpdateDBPTextFilesets:
 			parts = re.split("[-,]", verseNum)
 
 			verseStart = parts[0]
-			verseEnd = self.verseString2Int(bookId, chapter, parts[len(parts) -1])
+			verseEndNumber = self.verseString2Int(bookId, chapter, parts[len(parts) -1])
+			verseEnd = parts[len(parts) -1]
 			verseText = verseText.replace('\r', '')
 
 			if verseSequence > priorVerseEnd:
@@ -190,8 +191,8 @@ class UpdateDBPTextFilesets:
 			else:
 				(lastBookId, lastChapter, lastVerseStart, lastVerseEnd, lastVerseSequence, lastVerseText) = results.pop()
 				newVerseText = lastVerseText + '  ' + verseText
-				results.append((bookId, chapterNum, lastVerseStart, verseEnd, verseSequence, newVerseText))
-			priorVerseEnd = verseEnd
+				results.append((bookId, chapterNum, lastVerseStart, verseEnd, lastVerseSequence, newVerseText))
+			priorVerseEnd = verseEndNumber
 		bibleDB.close()
 		return results
 


### PR DESCRIPTION
## Description
 The type of the 'verse_end' column has been changed from string to integer, as we have decided to set this column equal to the 'verse_start' column.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-515

## Note 1:
@bradflood The following are the statements sql to change the column:


```shell
-- bible_verses
ALTER TABLE bible_verses modify column verse_end char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;

-- bible_file_timestamps
ALTER TABLE bible_file_timestamps_temp modify column verse_end char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;

-- bible_files
ALTER TABLE bible_files modify column verse_end char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;

-- user_highlights
ALTER TABLE dbp_users.user_highlights modify column verse_end char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;

-- user_notes
ALTER TABLE dbp_users.user_notes modify column verse_end char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;

````

## How Do I QA This
- I have executed the following command on my local environment:

```shell
## TXQWYIN1ET
python3 load/DBPLoadController.py test s3://etl-development-input TXQWYIN1ET

## BMUPNGN2ET
python3 load/DBPLoadController.py test s3://etl-development-input BMUPNGN2ET 

## TNTLAIN2ET
python3 load/DBPLoadController.py test s3://etl-development-input TNTLAIN2ET
``````
The following outcome is about the statement insets for each above folders and the `bible_verses` entidy:

- TXQWYIN1ET
[Trans-TXQWYIN_ET.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10429803/Trans-TXQWYIN_ET.sql.log)

- BMUPNGN2ET
[Trans-BMUPNGN_ET.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10429805/Trans-BMUPNGN_ET.sql.log)

- TNTLAIN2ET
[Trans-TNTLAIN_ET.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10429812/Trans-TNTLAIN_ET.sql.log)


 