### PR TITLE
FCBHDBP-555 uploader (python) - bible_file insert instead of update (keys don't match)

### DIFF
--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -246,7 +246,7 @@ class UpdateDBPFilesetTables:
 						verseEnd != dbpVerseEnd or
 						fileName != dbpFileName or
 						fileSize != dbpFileSize or
-						duration != dbpDuration):
+						(duration != dbpDuration and duration != None and duration != "") ):
 						updateRows.append((chapterEnd, verseEnd, fileName, fileSize, duration, verseSequence,
 						hashId, bookId, chapterStart, verseStart))
 
@@ -264,13 +264,13 @@ class UpdateDBPFilesetTables:
 
 	def convertChapterStart(self, bookId):
 		if bookId == "MAT":
-			return (28, 21, 21)
+			return (28, "21", "21")
 		elif bookId == "MRK":
-			return (16, 21, 21)
+			return (16, "21", "21")
 		elif bookId == "LUK":
-			return (24, 54, 54)
+			return (24, "54", "54")
 		elif bookId == "JHN":
-			return (21, 26, 26)
+			return (21, "26", "26")
 		else:
 			print("ERROR: Unexpected book %s in UpdateDBPDatabase." % (bookId))
 			sys.exit()


### PR DESCRIPTION
## Description
Modify the `insertBibleFiles` function to ensure that the keys related to 'bible_files' data are consistent during processing with those in the credits stream file. Additionally, implement a feature that updates the 'duration' column only if the compared values are different and the 'duration' value is not null or empty.

Dbp-etl was creating a INSERT statement because the keys are not matching due that the verseStart value fetched from etl was a integer (see convertChapterStart method invocation in this [line](https://github.com/faithcomesbyhearing/dbp-etl/blob/6636e04caead9cee845e5e771c8f6468303e4b47/load/UpdateDBPFilesetTables.py#L221)) and the verseStart value fetched from database was a string.

## NOTE 1
I have deactivated the invocation of method: `TranscodeVideo.transcodeVideoFileset` in local environment because I don't permissions to read and create a job using elasticTranscoder.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-555

## How do I QA this
- I have executed the following command on my local environment:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "TGKWBTP2DV"
```

- Outcome
I got the following sql file related to `bible_files` entity: [Trans-TGKWBTP2DV.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/10976554/Trans-TGKWBTP2DV.sql.log)

