### PR TITLE
FCBHDBP-556 uploader (python) for text: allow for missing verses

### DIFF
--- a/load/Config.py
+++ b/load/Config.py
@@ -119,6 +119,7 @@ class Config:
 		self.filename_accept_errors = self._getPath("filename.accept.errors")
 		self.filename_datetime = self._get("filename.datetime")
 		self.mysql_exe = self._getOptional("mysql.exe")
+		self.data_missing_verses_allowed = self._getOptional("data.missing_verses_allowed")
 
 		# TODO these dependencies need to be sorted out
 		if programRunning in {"DBPLoadController.py"}:

--- a/load/UpdateDBPTextFilesets.py
+++ b/load/UpdateDBPTextFilesets.py
@@ -6,6 +6,7 @@ import sys
 import os
 import re
 import sqlite3
+import json
 from Config import *
 from Log import *
 from LanguageReader import *
@@ -76,7 +77,8 @@ class UpdateDBPTextFilesets:
 			"run",
 			fullFilesetPath,
 			"--populate-db=%s" % (inputFilesetDBPath),
-			"--generate-json=%s" % (os.path.join(self.config.directory_accepted, inputFilesetId))]
+			"--generate-json=%s" % (os.path.join(self.config.directory_accepted, inputFilesetId)),
+			"--missing-verses-allowed=%s" % json.dumps(self.config.data_missing_verses_allowed).replace('\\', '')]
 		print("================= Invoke Sofria Cli ========================")
 		print("cmd: ", cmd)
 		print("============================================================")


### PR DESCRIPTION
## Description
Add a new option parameter to allow  to ignore any missing verses on the list. I have created a new data structure in the dbp-etl.cfg file to store the missing verses allowed. The structure looks like this:

```python
data.missing_verses_allowed = {
    "BOOK_ID": { 
        "CHAPTER_1" : [LIST_OF_VERSES],
        "CHAPTER_2" : [LIST_OF_VERSES],
        "CHAPTER_3" : [LIST_OF_VERSES] 
    }
}
```

To illustrate how it works, I have included some sample data for the books of Luke, Mark, and John:
```python
data.missing_verses_allowed = {
    "LUK": { "1" : [2, 5, 6], "3" : [6, 7, 8] },
    "MRK": { "4" : [2, 5, 6] },
    "JHN": { "11" : [9, 8, 1] },
}
```
The indexed array is sorted by book, chapter, and verses list. The purpose of this new data structure is to enable sofria_client to ignore any missing verses that are included in the "missing_verses_allowed" list. The goal is to send this list to sofria_client in JSON format, which will allow it to ignore any missing verses on the list.

We must to update the file: dbp-etl.cfg to set the missing_verses_allowed list e.g:

```python
data.missing_verses_allowed = { "LUK": { "1" : [2, 5, 6], "3" : [6, 7, 8] }, "MRK": { "4" : [2, 5, 6] }, "JHN": { "11" : [9, 8, 1] }, "DEU": { "31" : [2]}, "1SA": { "9": [10] } }
```
## NOTE 1
This PR depend on sofria-client PR # 22:
- https://github.com/faithcomesbyhearing/sofria-cli/pull/22

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-556

## How Do I QA This

- We could run the following command and it should pass but we would need to set the missing verses allowed list before:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input "Spanish_N2SPNBDA_USX"
```