### PR TITLE
FCBHDBP 568 - uploader (python) - error uploading video which had already been loaded - KFFNRVP2DV

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ The program can be run in the following ways:
 
 	filesetId can be any number of folders that are named after a filesetId, which contain files to be loaded.
 
+To debug we can use the pdb library.
 
+```python
+import pdb; pdb.set_trace()
+```
+When you run your script, execution will pause at the pdb.set_trace() call. You'll be able to inspect variables, step through your code, and do other things. Here are some commands you might find useful:
 
-
-
+- n(ext): Execute the next line.
+- s(tep): Step into a function call.
+- r(eturn): Continue execution until the current function returns.
+- c(ontinue): Continue execution until a breakpoint is encountered.
+- p(rint) <expression>: Evaluate the expression and print its value.
+- q(uit): Quit the debugger and exit.

--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -87,15 +87,19 @@ class DBPLoadController:
 		dbOut = SQLBatchExec(self.config)
 		update = UpdateDBPFilesetTables(self.config, self.db, dbOut)
 		video = UpdateDBPVideoTables(self.config, self.db, dbOut)
+
 		for inp in inputFilesets:
 			print("DBPLoadController:updateFilesetTables. processing fileset: %s" % (inp.filesetId))
 			hashId = update.processFileset(inp)
-			if inp.typeCode == "video":
-				video.processFileset(inp.filesetPrefix, inp.filenames(), hashId)
+
 			if inp.typeCode == "text" and inp.subTypeCode() == "text_json":
 				self.validateJSONFilesets(inp)
 			dbOut.displayCounts()
 			success = dbOut.execute(inp.batchName())
+			if success and inp.typeCode == "video":
+				video.processFileset(inp.filesetPrefix, inp.filenames(), hashId)
+				dbOut.displayCounts()
+				success = dbOut.execute(inp.batchName() + "-video")
 			RunStatus.set(inp.filesetId, success)
 			if success:
 				InputFileset.complete.append(inp)

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -74,7 +74,6 @@ class PreValidate:
 		filesetId = directoryName
 		filesetId1 = directoryName.split("-")[0]
 		damId = filesetId1.replace("_", "2")
-
 		results = self.languageReader.getFilesetRecords10(damId) # This method expects 10 digit DamId's always
 		if results == None:
 			damId = filesetId1.replace("_", "1")

--- a/load/S3Utility.py
+++ b/load/S3Utility.py
@@ -4,9 +4,7 @@
 #
 #
 
-import boto3
 import os
-import shutil
 import subprocess
 from Log import *
 from Config import *

--- a/load/SQLBatchExec.py
+++ b/load/SQLBatchExec.py
@@ -2,19 +2,19 @@
 
 # This program prepares and executes a single batch of SQL.
 
-import io
 import os
-import sys
 import re
 import time
-from datetime import datetime
 import subprocess
 from Config import *
 from DBPRunFilesS3 import *
 
 
 class SQLBatchExec:
-
+	# NOTE: We could improve this class by opening the database connection and having an instance of the connection to run statements.
+	# We could then start a transaction using this instance. This would allow us to execute any statement in the middle of the transaction
+	# and finish the transaction when necessary. This is beneficial because we might need to run a query to retrieve data in the middle of
+	# the transaction, and we would want any changes made up to that point to be taken into consideration.
 	def __init__(self, config):
 		self.config = config
 		self.statements = []

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -242,6 +242,11 @@ class UpdateDBPFilesetTables:
 				else:
 					del dbpMap[key]
 					(dbpChapterEnd, dbpVerseEnd, dbpFileName, dbpFileSize, dbpDuration) = dbpValue
+
+					# If the duration value is empty, it will keep the value retrieved from the database.
+					if inp.typeCode == "video" and duration == None and (dbpDuration != None or dbpDuration != ""):
+						duration = dbpDuration
+
 					if (chapterEnd != dbpChapterEnd or
 						verseEnd != dbpVerseEnd or
 						fileName != dbpFileName or

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -246,7 +246,7 @@ class UpdateDBPFilesetTables:
 						verseEnd != dbpVerseEnd or
 						fileName != dbpFileName or
 						fileSize != dbpFileSize or
-						duration != dbpDuration):
+						(duration != dbpDuration and duration != None and duration != "") ):
 						updateRows.append((chapterEnd, verseEnd, fileName, fileSize, duration, verseSequence,
 						hashId, bookId, chapterStart, verseStart))
 
@@ -264,13 +264,13 @@ class UpdateDBPFilesetTables:
 
 	def convertChapterStart(self, bookId):
 		if bookId == "MAT":
-			return (28, 21, 21)
+			return (28, "21", "21")
 		elif bookId == "MRK":
-			return (16, 21, 21)
+			return (16, "21", "21")
 		elif bookId == "LUK":
-			return (24, 54, 54)
+			return (24, "54", "54")
 		elif bookId == "JHN":
-			return (21, 26, 26)
+			return (21, "26", "26")
 		else:
 			print("ERROR: Unexpected book %s in UpdateDBPDatabase." % (bookId))
 			sys.exit()


### PR DESCRIPTION
## Description
We haved divided the process of updating the video tables into two sub-processes. The first sub-process will update the bible_filesets and bible_files records. Then, the second sub-process will update the bible_file_stream_bandwidths and bible_file_stream_ts records. This second process will incorporate the changes made by the first sub-process and won't throw an SQL error because a foreign key has been removed. I'll share the log file with the outcomes of these two sub-processes.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-568

## How do I QA this
- I have executed the following command on my local environment:

```shell
python3 load/UpdateDBPVideoTables.py test s3://etl-development-input/ "ENGESVP2DV"
```

- Outcome

First sub-process to update the `bible_filesets` and `bible_files records`
[sub-process_1_Trans-test-ENGESVP2DV.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/11691807/sub-process_1_Trans-test-ENGESVP2DV.sql.log)

Second sub-process to update the `bible_file_stream_bandwidths` and `bible_file_stream_ts` records.
[sub-process_2_Trans-test-video-ENGESVP2DV.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/11691808/sub-process_2_Trans-test-video-ENGESVP2DV.sql.log)
