### PR TITLE
FCBHDBP-582 continued work needed to fix duplicate key errors when loading video

### DIFF
--- a/load/Config.py
+++ b/load/Config.py
@@ -11,7 +11,6 @@
 import os
 import sys
 import re
-import boto3
 import configparser
 
 class Config:
@@ -152,6 +151,16 @@ class Config:
 		elif programRunning in {"AudioHLS.py"}:
 			self.directory_audio_hls = self._getPath("directory.audio_hls") #"%s/FCBH/files/tmp" % (self.home)
 			self.audio_hls_duration_limit = self._getInt("audio.hls.duration.limit") #10  #### Must become command line param
+
+		if profile == 'test':
+			self.video_transcoder_pipeline = self._get("video.transcoder.pipeline")
+			self.video_transcoder_mock = self._get("video.transcoder.mock")
+			self.video_transcoder_region = self._get("video.transcoder.region")
+			self.video_preset_hls_1080p = self._get("video.preset.hls.1080p")
+			self.video_preset_hls_720p = self._get("video.preset.hls.720p")
+			self.video_preset_hls_480p = self._get("video.preset.hls.480p")
+			self.video_preset_hls_360p = self._get("video.preset.hls.360p")
+			self.video_preset_web = self._get("video.preset.web")
 
 		if profile in {'test', 'dev'}:
 			self.database_names['dbp'] = self.hashMap.get("database.db_name")

--- a/load/TranscodeVideo.py
+++ b/load/TranscodeVideo.py
@@ -38,17 +38,25 @@ class TranscodeVideo:
 		self.hls_audio_video_360p = config.video_preset_hls_360p
 		self.web_audio_video = config.video_preset_web
 		self.web_audio_video = config.video_preset_web
-		self.video_transcoder_mock = json.loads(config.video_transcoder_mock) if hasattr(config, 'video_transcoder_mock') else {}
-		if self.video_transcoder_mock.get("enable") == 1:
-			self.client = boto3.client(
-				'elastictranscoder',
-				region_name=self.video_transcoder_mock.get("region_name"),
-				endpoint_url=self.video_transcoder_mock.get("endpoint_url")
-			)
-		else:
-			self.client = AWSSession.shared().elasticTranscoder()
+		self.client = self.getTranscoderClient()
 		self.openJobs = []
 
+	def getTranscoderClient(self):
+		if hasattr(self.config, 'video_transcoder_mock') and self.config.video_transcoder_mock != None:
+			try:
+				self.video_transcoder_mock = json.loads(self.config.video_transcoder_mock)
+			except json.JSONDecodeError:
+				# Handle the error and set a empty dict for self.video_transcoder_mock
+				self.video_transcoder_mock = {}
+
+			if self.video_transcoder_mock.get("enable") == 1:
+				return boto3.client(
+					'elastictranscoder',
+					region_name=self.video_transcoder_mock.get("region_name"),
+					endpoint_url=self.video_transcoder_mock.get("endpoint_url")
+				)
+
+		return AWSSession.shared().elasticTranscoder()
 
 	def createJob(self, file):
 		baseobj = file[:file.rfind(".")]

--- a/load/TranscodeVideo.py
+++ b/load/TranscodeVideo.py
@@ -1,7 +1,6 @@
 # TranscodeVideo.py
 
-import time
-import csv
+import json
 import boto3
 from S3Utility import *
 from RunStatus import *
@@ -32,13 +31,22 @@ class TranscodeVideo:
 	def __init__(self, config, filesetPrefix):
 		self.config = config
 		self.filesetPrefix = filesetPrefix
-		self.client = AWSSession.shared().elasticTranscoder()
 		self.videoPipeline = config.video_transcoder_pipeline
 		self.hls_audio_video_1080p = config.video_preset_hls_1080p
 		self.hls_audio_video_720p = config.video_preset_hls_720p
 		self.hls_audio_video_480p = config.video_preset_hls_480p
 		self.hls_audio_video_360p = config.video_preset_hls_360p
 		self.web_audio_video = config.video_preset_web
+		self.web_audio_video = config.video_preset_web
+		self.video_transcoder_mock = json.loads(config.video_transcoder_mock) if hasattr(config, 'video_transcoder_mock') else {}
+		if self.video_transcoder_mock.get("enable") == 1:
+			self.client = boto3.client(
+				'elastictranscoder',
+				region_name=self.video_transcoder_mock.get("region_name"),
+				endpoint_url=self.video_transcoder_mock.get("endpoint_url")
+			)
+		else:
+			self.client = AWSSession.shared().elasticTranscoder()
 		self.openJobs = []
 
 
@@ -114,16 +122,15 @@ class TranscodeVideo:
 					stillOpenJobs.append(jobId)
 			self.openJobs = stillOpenJobs
 			time.sleep(10)
-		return errorCount == 0	
+		return errorCount == 0
 
 
 if (__name__ == '__main__'):
-	from LanguageReaderCreator import LanguageReaderCreator	
+	from LanguageReaderCreator import LanguageReaderCreator
 	from InputProcessor import *
 
 	config = Config.shared()
 	languageReader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
-	# filesets = InputFileset.filesetCommandLineParser(config, languageReader)
 	filesets = InputProcessor.commandLineProcessor(config, AWSSession.shared().s3Client, languageReader)
 
 	for inp in filesets:
@@ -136,4 +143,4 @@ if (__name__ == '__main__'):
 # Successful tests with source on s3
 
 
-
+# python3 load/DBPLoadController.py test s3://etl-development-input/ "ENGESVP2DV"

--- a/load/UpdateDBPVideoTables.py
+++ b/load/UpdateDBPVideoTables.py
@@ -196,7 +196,6 @@ if (__name__ == '__main__'):
 
 	dbOut = SQLBatchExec(config)
 	update = UpdateDBPFilesetTables(config, db, dbOut)
-	video = UpdateDBPVideoTables(config, db, dbOut)
 
 	filesetsVideoProccessed = []
 	for inp in InputFileset.upload:
@@ -208,6 +207,10 @@ if (__name__ == '__main__'):
 	dbOut.displayStatements()
 	dbOut.displayCounts()
 	success = dbOut.execute("test-" + inp.filesetId)
+	db.close()
+
+	db = SQLUtility(config)
+	video = UpdateDBPVideoTables(config, db, dbOut)
 
 	if success and len(filesetsVideoProccessed) > 0:
 		for (filesetPrefix, filename, hashId) in filesetsVideoProccessed:
@@ -216,6 +219,8 @@ if (__name__ == '__main__'):
 		dbOut.displayStatements()
 		dbOut.displayCounts()
 		dbOut.execute("test-video-" + inp.filesetId)
+
+	db.close()
 
 # For these video tests to work, the filesets must have been uploaded by some other test, such as S3Utility.
 


### PR DESCRIPTION

## Description
The most recent modification involves dividing the process of updating Video Tables into two separate transactions. The first transaction updates the 'bible_filesets' and 'bible_files' records. Following this, the second transaction updates the 'bible_file_stream_bandwidths' and 'bible_file_stream_ts' records. However, I discovered an issue that necessitates closing the current database connection and initiating a new one after the first transaction. This ensures that any subsequent queries executed in the second transaction have access to the most recent changes pushed by the SQLBatchExec instance (dbOut). This is crucial as SQLBatchExec uses its own distinct database connection instance, separate from the 'self.db' instance used by the DBPLoadController class. See the following code line:
https://github.com/faithcomesbyhearing/dbp-etl/pull/112/files#diff-ab1709b9b91d4a426d9caf47a330754447695cee21f03ea3f61f9c5d76b3632fR99

Additionally, I've successfully mocked the AWS transcoding process and added configuration parameters to enable the use of this mock in the test environment. This mock allows dbp-etl to operate under the impression that the transcoding process has been executed successfully.

```python
self.video_transcoder_mock = json.loads(config.video_transcoder_mock) if hasattr(config, 'video_transcoder_mock') else {}
if self.video_transcoder_mock.get("enable") == 1:
	self.client = boto3.client(
		'elastictranscoder',
		region_name=self.video_transcoder_mock.get("region_name"),
		endpoint_url=self.video_transcoder_mock.get("endpoint_url")
	)
else:
	self.client = AWSSession.shared().elasticTranscoder()
```

The local AWS Elastic Transcoder mock creates an environment that simulates the Elastic Transcoder service, allowing dbp-etl to interact with it without needing to connect to the actual AWS service. This is achieved by creating a local API that replicates the AWS Elastic Transcoder and internally mimics FFmpeg for transcoding. For now, it will always be successful. The repository URL for the Mocking Transcoder is as follows:

https://github.com/vichugofsl/dbp-etl-mock-transcoder

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-582

## How do I QA this
- I have executed the following command on my local environment:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input/ "ENGESVP2DV"
```


