### PR TITLE
FCBHDBP-587 remove reference to dbp_users.

### DIFF
--- a/load/UpdateDBPBiblesTable.py
+++ b/load/UpdateDBPBiblesTable.py
@@ -8,8 +8,6 @@
 # also updated.
 
 
-import io
-import sys
 from Config import *
 from SQLUtility import *
 from SQLBatchExec import *
@@ -302,10 +300,6 @@ class UpdateDBPBiblesTable:
 
 	def testBibleForeignKeys(self, bibleId):
 		hasErrors = False
-		hasErrors |= self.testDeleteInTable(bibleId, self.config.database_user_db_name, "user_bookmarks")
-		hasErrors |= self.testDeleteInTable(bibleId, self.config.database_user_db_name, "user_highlights")
-		hasErrors |= self.testDeleteInTable(bibleId, self.config.database_user_db_name, "user_notes")
-		hasErrors |= self.testDeleteInTable(bibleId, self.config.database_user_db_name, "user_settings")
 		hasErrors |= self.testDeleteInTable(bibleId, self.config.database_db_name, "bible_translations")
 		return hasErrors
 


### PR DESCRIPTION
## Description
I removed reference to `dbp_users` and so, I have remove the queries that was pointing to the `dbp_users` tables keeping the query that was pointing to the bible_translations table.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-582

## How do I QA this
- I have executed the following command on my local environment:

```shell
python3 load/DBPLoadController.py test s3://etl-development-input/ "ENGESVP2DV"
```