### PR TITLE
FCBHDBP-588 Mocking Transcoder locally for audio.

### DIFF
--- a/load/Config.py
+++ b/load/Config.py
@@ -153,6 +153,7 @@ class Config:
 			self.audio_hls_duration_limit = self._getInt("audio.hls.duration.limit") #10  #### Must become command line param
 
 		if profile == 'test':
+			# video
 			self.video_transcoder_pipeline = self._get("video.transcoder.pipeline")
 			self.video_transcoder_mock = self._get("video.transcoder.mock")
 			self.video_transcoder_region = self._get("video.transcoder.region")
@@ -161,6 +162,10 @@ class Config:
 			self.video_preset_hls_480p = self._get("video.preset.hls.480p")
 			self.video_preset_hls_360p = self._get("video.preset.hls.360p")
 			self.video_preset_web = self._get("video.preset.web")
+			# audio
+			self.audio_transcoder_mock = self._get("audio.transcoder.mock")
+			self.audio_transcoder_sleep_sec = self._getInt("audio.transcoder.sleep.sec")
+			self.audio_transcoder_input = self._get("audio.transcoder.input")
 
 		if profile in {'test', 'dev'}:
 			self.database_names['dbp'] = self.hashMap.get("database.db_name")


### PR DESCRIPTION
## Description
Mocking Transcoder locally for audio. You can see the code in the following repository:

https://github.com/vichugofsl/dbp-etl-mock-transcoder

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-588

## How do I QA this
- I have executed the following command on my local environment:

```shell
python3 load/AWSTranscoder.py test s3://etl-development-input/ "JAAJARN2DA"
```

- Output
```shell
Config 'test' is loaded.
migration stage: [B]
LPTS Size. Prior: 5383, Current: 5383
LPTS Extract with 5383 records and 3105 BibleIds is loaded.
AWSSession. assume role arn: arn:aws:iam::869054869504:role/dbp-etl-dev
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
No stocknumber.txt file found. bucket [etl-development-input], fullPath: [JAAJARN2DA], key [JAAJARN2DA/stocknumber.txt]
InputFileset construction. filesetId: JAAJARN2DA location: s3://etl-development-input
Database 'dbp_2023_04_25' is opened.
AWSTranscoder:transcodeAudio... new output format: { "bucket": "dbp-staging", "key": "audio/JAAJAR/JAAJARN2DA-opus16", "bitrate": 16, "container": "webm", "codec": "opus" }
AWSTranscoder:transcodeAudio... after adding new output format. outputs size is : 1
AWSTranscoder:transcodeAudio... request to be sent to lambda:{"input": { "bucket": "etl-development-input", "key": "JAAJARN2DA" }, "output": [{ "bucket": "dbp-staging", "key": "audio/JAAJAR/JAAJARN2DA-opus16", "bitrate": 16, "container": "webm", "codec": "opus" }]}
AWSTranscoder:transcode....url: http://localhost:5000/job, key: mock, request: {"input": { "bucket": "etl-development-input", "key": "JAAJARN2DA" }, "output": [{ "bucket": "dbp-staging", "key": "audio/JAAJAR/JAAJARN2DA-opus16", "bitrate": 16, "container": "webm", "codec": "opus" }]}
AWSTranscoder jobId 1689714060215 for {"input": { "bucket": "etl-development-input", "key": "JAAJARN2DA" }, "output": [{ "bucket": "dbp-staging", "key": "audio/JAAJAR/JAAJARN2DA-opus16", "bitrate": 16, "container": "webm", "codec": "opus" }]}
AWSTranscoder:transcode. result from the transcoder lambda: {'files': [{'input': {'duration': 100, 'key': 'audio/JAAJAR/JAAJARN2DA-opus16/XNM___NM_Book_____FILESETID.mp3'}, 'output': {'duration': 101, 'key': 'audio/JAAJAR/JAAJARN2DA/XNM___NM_Book____FILESETID.mp3'}}], 'id': '1689714060215', 'output': [{'bitrate': 16, 'bucket': 'dbp-staging', 'codec': 'opus', 'container': 'webm', 'key': 'audio/JAAJAR/JAAJARN2DA'}], 'status': 'Complete'}
AWSTranscoder:parseAudioResponse. inpFileset: <InputFileset.InputFileset object at 0x7fdded075900>, response: {'files': [{'input': {'duration': 100, 'key': 'audio/JAAJAR/JAAJARN2DA-opus16/XNM___NM_Book_____FILESETID.mp3'}, 'output': {'duration': 101, 'key': 'audio/JAAJAR/JAAJARN2DA/XNM___NM_Book____FILESETID.mp3'}}], 'id': '1689714060215', 'output': [{'bitrate': 16, 'bucket': 'dbp-staging', 'codec': 'opus', 'container': 'webm', 'key': 'audio/JAAJAR/JAAJARN2DA'}], 'status': 'Complete'}
AWSTranscoder:parseAudioResponse. count of outputs: 1
InputFileset construction. filesetId: JAAJARN2DA location: s3://dbp-staging
AWSTranscoder:parseAudioResponse. count of files: 1
AWSTranscoder:transcodeAudio... outfileset: <InputFileset.InputFileset object at 0x7fddeca1cd00>
InputFileset
 location=dbp-staging
 filesetPath=audio/JAAJAR/JAAJARN2DA
 fullPath=dbp-staging/audio/JAAJAR/JAAJARN2DA
 locationType=BUCKET prefix=audio/JAAJAR/JAAJARN2DA  damId=JAAJARN2DA  stockNum=N2JAA/JAR  index=1  subTypeCode=None  script=Latin
 filesetPrefix=audio/JAAJAR/JAAJARN2DA
 csvFilename=/home/vichugof/files/accepted/audio_JAAJAR_JAAJARN2DA.csv
 name=XNM___NM_Book____FILESETID.mp3 size=0 date=2023-07-18 16:01:01 duration=101.000

```
