### PR TITLE
FCBHDBP-584 uploader (python) - assign download permissions (19x) for all content from SIL MSEA

### DIFF
--- a/load/Config.py
+++ b/load/Config.py
@@ -119,6 +119,7 @@ class Config:
 		self.filename_datetime = self._get("filename.datetime")
 		self.mysql_exe = self._getOptional("mysql.exe")
 		self.data_missing_verses_allowed = self._getOptional("data.missing_verses_allowed")
+		self.data_org_has_granted_general_download_permission = self._getOptional("data.org_has_granted_general_download_permission")
 
 		# TODO these dependencies need to be sorted out
 		if programRunning in {"DBPLoadController.py"}:


### PR DESCRIPTION
## Description
Since ETL needed to add 'SIL MSEA' to the list of organizations that are granted general download permission, but couldn't implement this using a wildcard match on the licensor string, I have implemented new logic. This logic reads from the configuration and provides download permissions to a specific list of organizations.

## NOTE
This PR has worked on the ticket [DBP-585 (uploader (python) - delete from access_group_filesets if not in LPTS (except 19x)](https://fullstacklabs.atlassian.net/browse/FCBHDBP-585) as well.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-584

## How do I QA this
- I have executed the following command on my local environment:

```shell
python3 load/UpdateDBPAccessTable.py test
```

- Output
[Trans-test-lpts-2020-07-24.sql.log](https://github.com/faithcomesbyhearing/dbp-etl/files/12155756/Trans-test-lpts-2020-07-24.sql.log)

