### PR TITLE
fix externally managed environment error in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,22 @@ WORKDIR /app
 
 RUN apk update
 RUN apk add aws-cli ffmpeg jq mysql-client nodejs python3 py3-pip
+
+# --
+# To get past the "externally-managed-environment" error
+# it looks like there are (at least) two choices:
+
+# Set this environment variable to allow system and eternally managed to coexist
+#ENV PIP_BREAK_SYSTEM_PACKAGES 1
+
+# OR create and activate a virtual environment
+ENV VIRTUAL_ENV=/app/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN python -m venv $VIRTUAL_ENV
+RUN /bin/sh -c "source $VIRTUAL_ENV/bin/activate"
+# --
+
 RUN pip install boto3 pymysql pytz
 
 COPY --from=Sofria /app/sofria-cli ./sofria-cli


### PR DESCRIPTION
These changes were added to address an error in the docker build for dbp-etl-dev ([see build log](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/078432969830/projects/dbp-etl-docker-dev/build/dbp-etl-docker-dev%3A7ac55fbd-e514-4966-abff-da9854a9cda4/?region=us-west-2))

See the Dockerfile for the explanation of the fixes (either an overriding env var, or using a virtual environment)

@vichugofsl - please review and fix if you know of a better way



