### PR TITLE
Task-2049 uploader: delete access groups if not in LPTS and not in 19x

### DIFF
--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -63,8 +63,8 @@ class UpdateDBPAccessTable:
 					accessIdInLPTS = lpts.get(accessDesc) == "-1" and "OT" in setSizeCode
 				elif accessId == 181: # allow_text_DOWNLOAD
 					accessIdInLPTS = self._isPublicDomain(languageRecord)
-				elif accessId in {191, 193}: # allow_text_APP_OFFLINE and allow_audio_APP_OFFLINE
-					accessIdInLPTS = self._isSILOnly(languageRecord) or self._isPioneerBibleTranslatorsOnly(languageRecord) or self._isPublicDomain(languageRecord) or self._isCreativeCommons(languageRecord)
+				# elif accessId in {191, 193}: # allow_text_APP_OFFLINE and allow_audio_APP_OFFLINE
+				# 	accessIdInLPTS = self._isSILOnly(languageRecord) or self._isPioneerBibleTranslatorsOnly(languageRecord) or self._isPublicDomain(languageRecord) or self._isCreativeCommons(languageRecord)
 					# if (accessIdInLPTS):
 					# 	print("*** 191/193... SIL: %s, PBT: %s, Public Domain: %s, CC: %s, hashId: %s, filesetId: %s" % (self._isSILOnly(languageRecord), self._isPioneerBibleTranslatorsOnly(languageRecord), self._isPublicDomain(languageRecord),self._isCreativeCommons(languageRecord), hashId, filesetId))
 				else:
@@ -73,7 +73,10 @@ class UpdateDBPAccessTable:
 				if accessIdInLPTS and not accessIdInDBP:
 					insertRows.append((hashId, accessId))
 				elif accessIdInDBP and not accessIdInLPTS:
-					print("accessId not in DBP or LPTS, but not deleting.. accessId: %s hashId: %s" % (accessId, hashId))
+					if accessId not in {191, 193}:
+						# accessId is in DBP but not in LPTS. For accessIds 19x, this was done manually and should be left alone.
+						# for all others, this is a signal from LPTS to delete from DBP
+						deleteRows.append((hashId, accessId))
 
 		tableName = "access_group_filesets"
 		pkeyNames = ("hash_id", "access_group_id")

--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -47,7 +47,7 @@ class UpdateDBPAccessTable:
 				print("FATAL: Unknown typeCode % in fileset: %s, hashId: %s" % (typeCode, filesetId, hashId))
 				sys.exit()
 
-			(languageRecord, lptsIndex) = self.languageReader.getLanguageRecord(typeCode, bibleId, dbpFilesetId)
+			(languageRecord, _) = self.languageReader.getLanguageRecord(typeCode, bibleId, dbpFilesetId)
 			if languageRecord != None:
 				lpts = languageRecord.record
 			else:
@@ -55,7 +55,7 @@ class UpdateDBPAccessTable:
 				print ("getLanguageRecord method did not return a record for typeCode: %s, bibleId: %s, dbpFilesetId: %s " % ( typeCode, bibleId, dbpFilesetId))
 
 
-			for (accessId, accessName, accessDesc) in accessTypes:
+			for (accessId, _, accessDesc) in accessTypes:
 				accessIdInDBP = accessId in dbpAccessSet;
 				if accessId == 101: # allow_text_NT_DBP
 					accessIdInLPTS = lpts.get(accessDesc) == "-1" and "NT" in setSizeCode


### PR DESCRIPTION
# Description
delete access id if not in LPTS and not 19x (offline permissions)

# Task
[User Story 2049](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2049): uploader: delete access groups if not in LPTS and not in 19x

# How to test
Run the following command
```shell
python3 load/UpdateDBPAccessTable.py test
```

# Results
I have tested it in my local environment and you can see that the offline permissions are not being removed as you can see in the following file:

[Trans-test-lpts_sql.txt](https://github.com/faithcomesbyhearing/dbp-etl/files/14726279/Trans-test-lpts_sql.txt)
