### PR TITLE
Don't delete access_groups 101 and 102 during Blimp transition

### DIFF
--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -73,9 +73,11 @@ class UpdateDBPAccessTable:
 				if accessIdInLPTS and not accessIdInDBP:
 					insertRows.append((hashId, accessId))
 				elif accessIdInDBP and not accessIdInLPTS:
-					if accessId not in {191, 193}:
-						# accessId is in DBP but not in LPTS. For accessIds 19x, this was done manually and should be left alone.
-						# for all others, this is a signal from LPTS to delete from DBP
+					# accessId is in DBP but not in LPTS. 
+  					# For accessIds 101 and 102, there is a bug in the fileset setSizeCode. Don't delete for now.
+					# For accessIds 19x, this was done manually and should be left alone.
+					# for all others, this is a signal from LPTS to delete from DBP
+					if accessId not in {101,102, 191, 193}:
 						deleteRows.append((hashId, accessId))
 
 		tableName = "access_group_filesets"


### PR DESCRIPTION
For certain bible texts, there is a bug regarding the set type code (Azure Devops 2137). This is causing thrashing (delete a row in one load, insert it in the next) that is noisy when evaluating the lpts upload during the blimp transition.

The affected hash_ids are associated with content not yet loaded, so this change will not provide unauthorized access to content.

This ticket will remove the logic to delete from 101 / 102 during the transition.