### PR TITLE
Task-2172 associate license org

### DIFF
--- a/load/LoadOrganizations.py
+++ b/load/LoadOrganizations.py
@@ -3,6 +3,7 @@
 import os
 import re
 import unicodedata
+from SQLBatchExec import SQLBatchExec
 
 class LoadOrganizations:
 	def __init__(self, config, db, dbOut, languageReader):
@@ -206,7 +207,7 @@ class LoadOrganizations:
 		org_values = [(licensor_name_slug,)]
 
 		# organization_translations
-		org_trans_values = [(licensor_name_sql_key, licensor_name, licensor_name, 6414)]
+		org_trans_values = [(licensor_name_sql_key, licensor_name.replace("'", "\\'"), licensor_name.replace("'", "\\'"), 6414)]
 		org_trans_attr_values = ("organization_id", "name", "description")
 		org_trans_pkey_names = ("language_id",)
 
@@ -405,7 +406,6 @@ class LoadOrganizations:
 if (__name__ == '__main__'):
 	from Config import Config
 	from SQLUtility import SQLUtility
-	from SQLBatchExec import SQLBatchExec
 	from LanguageReaderCreator import LanguageReaderCreator
 
 	config = Config()


### PR DESCRIPTION
# Description
Include `SQLBatchExec` in the `LoadOrganizations.py` class to avoid that it throws error when `load/DBPLoadController.py` invokes the  method `LoadOrganizations.update_database`. Additionally, added extra quotes to the licensor name in the insert statements. This change will prevent SQL statement failures during execution.

For example we need to add extra quotes to get the following insert:
```sql
INSERT IGNORE INTO organization_translations (organization_id, name, description, language_id) VALUES (@God_s_Word_to_the_Nations_Mission_Society__Inc_, 'God\'s Word to the Nations Mission Society, Inc.', 'God\'s Word to the Nations Mission Society, Inc.', '6414');
```

# Task
[User Story 2172](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2172): associate license orgs for LORA
[User Story 2174](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2174): associate org licenses for "Text Only"
[User Story 2173](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2173): associate org licenses with TextAgreement