### PR TITLE
develop to master: Correct Licensor assignments

### DIFF
--- a/load/SQLBatchExec.py
+++ b/load/SQLBatchExec.py
@@ -26,7 +26,7 @@ class SQLBatchExec:
 		if len(values) > 0:
 			names = attrNames + pkeyNames
 			valsubs = ["'%s'"] * len(names)
-			sql = "INSERT INTO %s (%s) VALUES (%s);" % (tableName, ", ".join(names), ", ".join(valsubs))
+			sql = "INSERT IGNORE INTO %s (%s) VALUES (%s);" % (tableName, ", ".join(names), ", ".join(valsubs))
 			for value in values:
 				stmt = sql % value
 				stmt = self.unquoteValues(stmt)
@@ -40,7 +40,7 @@ class SQLBatchExec:
 	def insertSet(self, tableName, pkeyNames, attrNames, values):
 		if len(values) > 0:
 			names = attrNames + pkeyNames
-			stmt = "INSERT INTO %s (%s) VALUES " % (tableName, ", ".join(names))
+			stmt = "INSERT IGNORE INTO %s (%s) VALUES " % (tableName, ", ".join(names))
 			self.statements.append(stmt)
 			valsubs = ["'%s'"] * len(names)
 			sql = "(%s)," % (", ".join(valsubs))

--- a/load/SQLBatchExec.py
+++ b/load/SQLBatchExec.py
@@ -157,8 +157,14 @@ class SQLBatchExec:
 			tranFile = open(path, "w", encoding="utf-8")
 			tranFile.write("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;\n")
 			tranFile.write("START TRANSACTION;\n")
+			count = 0 
 			for statement in self.statements:
 				tranFile.write(statement + "\n")
+				## temporary only for massive one-time load
+				count+= 1
+				if (count > 1000):
+					tranFile.write("COMMIT;\n")
+					count = 0 
 			tranFile.write("COMMIT;\n")
 			tranFile.write("EXIT\n")
 			tranFile.close()

--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -135,6 +135,7 @@ if (__name__ == '__main__'):
 	filesets = UpdateDBPAccessTable(config, db, dbOut, languageReader)
 	sql = ("SELECT b.bible_id, bf.id, bf.set_type_code, bf.set_size_code, bf.asset_id, bf.hash_id"
 			" FROM bible_filesets bf JOIN bible_fileset_connections b ON bf.hash_id = b.hash_id"
+			" WHERE bf.content_loaded = 1 "
 			" ORDER BY b.bible_id, bf.id, bf.set_type_code")
 	filesetList = db.select(sql, ())
 	filesets.process(filesetList)

--- a/load/UpdateDBPAccessTable.py
+++ b/load/UpdateDBPAccessTable.py
@@ -73,9 +73,11 @@ class UpdateDBPAccessTable:
 				if accessIdInLPTS and not accessIdInDBP:
 					insertRows.append((hashId, accessId))
 				elif accessIdInDBP and not accessIdInLPTS:
-					if accessId not in {191, 193}:
-						# accessId is in DBP but not in LPTS. For accessIds 19x, this was done manually and should be left alone.
-						# for all others, this is a signal from LPTS to delete from DBP
+					# accessId is in DBP but not in LPTS. 
+  					# For accessIds 101 and 102, there is a bug in the fileset setSizeCode. Don't delete for now.
+					# For accessIds 19x, this was done manually and should be left alone.
+					# for all others, this is a signal from LPTS to delete from DBP
+					if accessId not in {101,102, 191, 193}:
 						deleteRows.append((hashId, accessId))
 
 		tableName = "access_group_filesets"

--- a/load/UpdateDBPBiblesTable.py
+++ b/load/UpdateDBPBiblesTable.py
@@ -32,7 +32,7 @@ class UpdateDBPBiblesTable:
 		self.scriptCodeMap = self.db.selectMap(sql, ())
 		self.scriptNameMap = self.db.selectMap("SELECT lpts_name, script_id FROM lpts_script_codes", ())
 		self.numeralIdSet = self.db.selectSet("SELECT id FROM numeral_systems", ())
-		self.sizeCodeMap = self.db.selectMapList("SELECT id, set_size_code FROM bible_filesets", ())	
+		self.sizeCodeMap = self.db.selectMapList("SELECT id, set_size_code FROM bible_filesets where content_loaded = 1", ())	
 		resultSet = self.db.select("SELECT lower(l.iso), lower(t.name), l.id FROM languages l,language_translations t"
 			" WHERE l.id=t.language_source_id AND priority = 9 ORDER BY l.id desc", ())
 		self.languageMap1 = {}

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -44,15 +44,19 @@ class UpdateDBPLPTSTable:
 		RunStatus.printDuration("BEGIN LPTS UPDATE")
 
 		# get the biblefilesets that will be inserted or updated
-		filesetList = self.upsertBibleFilesetsAndConnections()
-
-		# we need to use the list of the new bible_filesets because the upsertBibleFilesetsAndConnections have not stored into database the record for now
+		newFilesetList = self.upsertBibleFilesetsAndConnections()		
 
 		# now, with the full list of bible_filesets, we can continue with normal processing
-		# sql = ("SELECT b.bible_id, bf.id, bf.set_type_code, bf.set_size_code, bf.asset_id, bf.hash_id"
-		# 	" FROM bible_filesets bf JOIN bible_fileset_connections b ON bf.hash_id = b.hash_id"
-		# 	" ORDER BY b.bible_id, bf.id, bf.set_type_code")
-		# filesetList = self.db.select(sql, ())
+		sql = ("SELECT b.bible_id, bf.id, bf.set_type_code, bf.set_size_code, bf.asset_id, bf.hash_id"
+			" FROM bible_filesets bf JOIN bible_fileset_connections b ON bf.hash_id = b.hash_id"
+			" ORDER BY b.bible_id, bf.id, bf.set_type_code")
+		filesetList = self.db.select(sql, ())
+
+		# we need to use the list of the new bible_filesets because the upsertBibleFilesetsAndConnections have not stored into database the record for now.
+		# but we also need to capture the "derived" filesets (eg transcoded opus16) when content is loaded 
+		# FIXME: combine filesetList (from DB) and newFilesetList (which has not been committed yet)
+		# this will capture opus16 for new content load as well as new biblefilesets from metadata load
+
 		access = UpdateDBPAccessTable(self.config, self.db, self.dbOut, self.languageReader)
 		access.process(filesetList)
 		self.updateBibleFilesetTags(filesetList)

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -56,7 +56,8 @@ class UpdateDBPLPTSTable:
 		# but we also need to capture the "derived" filesets (eg transcoded opus16) when content is loaded 
 		# combine filesetList (from DB) and newFilesetList (which has not been committed yet)
 		# this will capture opus16 for new content load as well as new biblefilesets from metadata load
-		filesetList = filesetList1 + list(filesetList2)
+		# Also, some filesets will be in both lists, so remove dups using a set
+		filesetList = list(set(filesetList1 + list(filesetList2)))
 
 		access = UpdateDBPAccessTable(self.config, self.db, self.dbOut, self.languageReader)
 		access.process(filesetList)

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -44,19 +44,19 @@ class UpdateDBPLPTSTable:
 		RunStatus.printDuration("BEGIN LPTS UPDATE")
 
 		# get the biblefilesets that will be inserted or updated
-		newFilesetList = self.upsertBibleFilesetsAndConnections()		
+		filesetList1 = self.upsertBibleFilesetsAndConnections()		
 
 		# now, with the full list of bible_filesets, we can continue with normal processing
 		sql = ("SELECT b.bible_id, bf.id, bf.set_type_code, bf.set_size_code, bf.asset_id, bf.hash_id"
 			" FROM bible_filesets bf JOIN bible_fileset_connections b ON bf.hash_id = b.hash_id"
 			" ORDER BY b.bible_id, bf.id, bf.set_type_code")
-		filesetList = self.db.select(sql, ())
+		filesetList2 = self.db.select(sql, ())
 
 		# we need to use the list of the new bible_filesets because the upsertBibleFilesetsAndConnections have not stored into database the record for now.
 		# but we also need to capture the "derived" filesets (eg transcoded opus16) when content is loaded 
 		# combine filesetList (from DB) and newFilesetList (which has not been committed yet)
 		# this will capture opus16 for new content load as well as new biblefilesets from metadata load
-		filesetList.extend(newFilesetList)
+		filesetList = filesetList1 + filesetList2
 
 		access = UpdateDBPAccessTable(self.config, self.db, self.dbOut, self.languageReader)
 		access.process(filesetList)

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -207,7 +207,6 @@ class UpdateDBPLPTSTable:
 					tagNameList = ["stock_no", "volume"]
 
 				(languageRecord, lptsIndex) = self.languageReader.getLanguageRecordLoose(typeCode, bibleId, dbpFilesetId)
-				print("   languageRecordLoose... stocknumber: %s" % (languageRecord.Reg_StockNumber()))
 
 				tagMap = tagHashIdMap.get(hashId, {})
 				for name in tagNameList:

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -56,7 +56,7 @@ class UpdateDBPLPTSTable:
 		# but we also need to capture the "derived" filesets (eg transcoded opus16) when content is loaded 
 		# combine filesetList (from DB) and newFilesetList (which has not been committed yet)
 		# this will capture opus16 for new content load as well as new biblefilesets from metadata load
-		filesetList = filesetList1 + filesetList2
+		filesetList = filesetList1 + list(filesetList2)
 
 		access = UpdateDBPAccessTable(self.config, self.db, self.dbOut, self.languageReader)
 		access.process(filesetList)

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -152,8 +152,6 @@ class UpdateDBPLPTSTable:
 	## Bible Fileset Tags
 	##
 	def updateBibleFilesetTags(self, filesetList):
-		print("\nUpdateBibleFilesetTags. enter")
-
 		insertRows = []
 		updateRows = []
 		deleteRows = []
@@ -177,8 +175,6 @@ class UpdateDBPLPTSTable:
 			tagHashIdMap[hashId] = tagMap
 		
 		for (bibleId, filesetId, setTypeCode, setSizeCode, assetId, hashId) in filesetList:
-			if hashId == "5a7fb6b8c42a":
-				print("DEBUG TAGS (text)..: %s %s %s %s" % (bibleId, filesetId, setTypeCode, hashId))			
 			typeCode = setTypeCode.split("_")[0]
 			if typeCode != "app":
 				if filesetId[8:10] == "SA":
@@ -244,11 +240,6 @@ class UpdateDBPLPTSTable:
 							sys.exit()
 					else:
 						description = None
-
-
-						if hashId == "5a7fb6b8c42a":
-							print("   filesetId: %s, hashId: %s, name: %s,  oldDescription: %s, description: %s" % (filesetId, hashId, name, oldDescription, description))
-
 
 					if oldDescription != None and description == None:
 						deleteRows.append((hashId, name, languageId))

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -108,7 +108,7 @@ class UpdateDBPLPTSTable:
 	## Bible Filesets
 	##
 	def upsertBibleFilesetsAndConnections(self):
-		indexMap = {"audio": [1, 2, 3], "text": [1, 2, 3], "video": [1]}
+		indexMap = {"audio": [1, 2, 3], "text": [1, 2, 3], "video": [1, 2, 3 ]}
 
 		lptsFilesetList = []
 		lptsFilesetProcessed = {}

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -152,6 +152,8 @@ class UpdateDBPLPTSTable:
 	## Bible Fileset Tags
 	##
 	def updateBibleFilesetTags(self, filesetList):
+		print("\nUpdateBibleFilesetTags. enter")
+
 		insertRows = []
 		updateRows = []
 		deleteRows = []
@@ -175,6 +177,7 @@ class UpdateDBPLPTSTable:
 			tagHashIdMap[hashId] = tagMap
 		
 		for (bibleId, filesetId, setTypeCode, setSizeCode, assetId, hashId) in filesetList:
+			print("DEBUG TAGS..: %s %s %s %s" % (bibleId, filesetId, setTypeCode, hashId))			
 			typeCode = setTypeCode.split("_")[0]
 			if typeCode != "app":
 				if filesetId[8:10] == "SA":
@@ -204,6 +207,7 @@ class UpdateDBPLPTSTable:
 					tagNameList = ["stock_no", "volume"]
 
 				(languageRecord, lptsIndex) = self.languageReader.getLanguageRecordLoose(typeCode, bibleId, dbpFilesetId)
+				print("   languageRecordLoose... stocknumber: %s" % (languageRecord.Reg_StockNumber()))
 
 				tagMap = tagHashIdMap.get(hashId, {})
 				for name in tagNameList:
@@ -240,6 +244,10 @@ class UpdateDBPLPTSTable:
 							sys.exit()
 					else:
 						description = None
+
+
+					print("   filesetId: %s, hashId: %s, name: %s,  oldDescription: %s, description: %s" % (filesetId, hashId, name, oldDescription, description))
+
 
 					if oldDescription != None and description == None:
 						deleteRows.append((hashId, name, languageId))

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -54,8 +54,9 @@ class UpdateDBPLPTSTable:
 
 		# we need to use the list of the new bible_filesets because the upsertBibleFilesetsAndConnections have not stored into database the record for now.
 		# but we also need to capture the "derived" filesets (eg transcoded opus16) when content is loaded 
-		# FIXME: combine filesetList (from DB) and newFilesetList (which has not been committed yet)
+		# combine filesetList (from DB) and newFilesetList (which has not been committed yet)
 		# this will capture opus16 for new content load as well as new biblefilesets from metadata load
+		filesetList.extend(newFilesetList)
 
 		access = UpdateDBPAccessTable(self.config, self.db, self.dbOut, self.languageReader)
 		access.process(filesetList)

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -177,7 +177,8 @@ class UpdateDBPLPTSTable:
 			tagHashIdMap[hashId] = tagMap
 		
 		for (bibleId, filesetId, setTypeCode, setSizeCode, assetId, hashId) in filesetList:
-			print("DEBUG TAGS..: %s %s %s %s" % (bibleId, filesetId, setTypeCode, hashId))			
+			if hashId == "5a7fb6b8c42a":
+				print("DEBUG TAGS (text)..: %s %s %s %s" % (bibleId, filesetId, setTypeCode, hashId))			
 			typeCode = setTypeCode.split("_")[0]
 			if typeCode != "app":
 				if filesetId[8:10] == "SA":
@@ -245,7 +246,8 @@ class UpdateDBPLPTSTable:
 						description = None
 
 
-					print("   filesetId: %s, hashId: %s, name: %s,  oldDescription: %s, description: %s" % (filesetId, hashId, name, oldDescription, description))
+						if hashId == "5a7fb6b8c42a":
+							print("   filesetId: %s, hashId: %s, name: %s,  oldDescription: %s, description: %s" % (filesetId, hashId, name, oldDescription, description))
 
 
 					if oldDescription != None and description == None:

--- a/load/UpdateDBPVideoTables.py
+++ b/load/UpdateDBPVideoTables.py
@@ -20,7 +20,7 @@ class UpdateDBPVideoTables:
 		self.dbOut = dbOut
 		self.s3Utility = S3Utility(config)
 		sql = ("SELECT file_name, id FROM bible_files where hash_id in"
-			" (SELECT hash_id FROM bible_filesets WHERE set_type_code = 'video_stream')")
+			" (SELECT hash_id FROM bible_filesets WHERE content_loaded = 1 and set_type_code = 'video_stream')")
 		self.fileIdMap = db.selectMap(sql, ())
 		self.streamRegex = re.compile(r"BANDWIDTH=([0-9]+),RESOLUTION=([0-9]+)x([0-9]+),CODECS=\"(.+)\"")
 		self.tsRegex = re.compile(r"#EXTINF:([0-9\.]+),")


### PR DESCRIPTION
The primary capability being added is to correctly interpret the LPTS extract data so that licensors are associated correctly. This will handle agreement types of "Text Agreement" and "LORA", as well as Recording Status "Text Only". 

This PR also adds a capability to the language mapper, so that it now attempts to link languages between LPTS and Biblebrain using iso code, FCBH Language Name, and Country. Previously, we only considered iso code and FCBH Language Name