### PR TITLE
Task-2176 Uploader: associate license orgs for  "Other"

### DIFF
--- a/load/LoadOrganizations.py
+++ b/load/LoadOrganizations.py
@@ -111,7 +111,6 @@ class LoadOrganizations:
 				else:
 					print(f"ERROR Agreement Type is 'Other' and Methodology 'TraditionalRecording' but licensor is empty for fileset id: {fileset_id}")
 			else:
-				print(f"ERROR Agreement Type is 'Other', Methodology is TraditionalRecording, but type is not text. Unable to assign for fileset id: {fileset_id}")
 				return None
 
 			return licensors
@@ -165,8 +164,9 @@ class LoadOrganizations:
 					licensors.append(language_record.Licensor())
 				else:
 					print(f"ERROR Agreement Type is 'Other' and Methodology 'Render' but licensor is empty for fileset id: {fileset_id}")
+			elif type_code == "audio":
+				licensors.append(self.LicensorHosanna)
 			else:
-				print(f"ERROR Agreement Type is 'Other', Methodology is 'Render', but type is not text. Unable to assign for fileset id: {fileset_id}")
 				return None
 
 		return None


### PR DESCRIPTION
# Description
Added logic to handle the audio fileset within the Other `Agreement/Render` option. Also, removed the log from the `Other/TraditionalRecording` option when the fileset is not audio, as it is being handled by the video process method.

# Task
[User Story 2176](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2176): Uploader: associate license orgs for  "Other"
[User Story 2179](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2179): associate org licenses for video (via copyright statement)

# How to test
- You run the following command you will have a similar outcome.

```shell
python3 load/LoadOrganizations.py test 
```
- Outcome
[log_update_bibles_table.txt](https://github.com/faithcomesbyhearing/dbp-etl/files/15326784/log_update_bibles_table.txt)

## Notes

I have noted that some warnings messages has been removed but I can see the following warning messages:

```shell
WARN Agreement Type is 'Other' and Methodology 'Hear This'. We are not able to process for fileset id: BZIWYI
WARN Agreement Type is 'Other' and Methodology 'Partner' but co-licensor is empty for fileset id: ENGNIRN_ET
ERROR Agreement Type is 'Other', ambiguous methodology and it needs to be fixed for fileset id: CJAWYIP2DA

```