### PR TITLE
Task 2183 uploader - set archived flag when recording status in Discontinued / Inactive / Void

### DIFF
--- a/load/LoadOrganizations.py
+++ b/load/LoadOrganizations.py
@@ -319,7 +319,11 @@ class LoadOrganizations:
 		table_name_org_trans = "organization_translations"
 		licensor_name_slug = self.create_licensor_slug(licensor_name)
 		# Create a unique temp variable to store the organization id to create the relationship
-		licensor_name_sql_key = "@" + SQLBatchExec.sanitize_value(licensor_name)
+		licensor_name_sql_key = "@" + SQLBatchExec.sanitize_value(licensor_name_slug)
+		# Check using the slug if the organization exists or not
+		result = self.db.selectScalar("SELECT id FROM organizations WHERE slug=%s", (licensor_name_slug))
+		if result != None:
+			return result
 
 		# organization
 		org_attr_names = ("slug",)


### PR DESCRIPTION
# Description
It has added logic to set archived flag for a specific fileset when recording status in Discontinued, Inactive or Void. Improved logic to remove duplicate fileset records when ETL executes the UpdateDBPLPTSTable process.

# Task
[User Story 2183](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2183): uploader - set archived flag when recording status in Discontinued / Inactive / Void

# How to test
You should run the following command and the outcome should be the following:
```shell
python3 load/LoadOrganizations.py test
```

- Outcome
[Trans-test-lpts.sql.txt](https://github.com/faithcomesbyhearing/dbp-etl/files/15370268/Trans-test-lpts.sql.txt)
