### PR TITLE
Task-2190 

### DIFF
--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -278,7 +278,7 @@ if (__name__ == '__main__'):
 	ctrl.validate(filesets)
 
 	dbOut = SQLBatchExec(config)
-	update = UpdateDBPFilesetTables(config, db, dbOut)
+	update = UpdateDBPFilesetTables(config, db, dbOut, languageReader)
 	for inp in InputFileset.upload:
 		hashId = update.processFileset(inp)
 

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -380,7 +380,7 @@ class UpdateDBPLPTSTable:
 			(_, _, _, _, dbpContentLoaded, _) = row
 			if dbpContentLoaded != isContentLoaded:
 				updateRows.append((filesetId, bucket, setTypeCode, setSizeCode, isContentLoaded, hashId))
-				self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
+				self.dbOut.update(tableName, pkeyNames, attrNamesToUpdate, updateRows)
 				return hashId
 
 		if isArchived == 1:


### PR DESCRIPTION
# Description
Fixed an issue that was preventing the SQL statement from being built to update a bible_fileset record. It was not using the correct attrNames to build the SQL statament.

# Task
[Bug 2190](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2190): uploader text processing  - SQLExec error

# How to test
I have executed the following command I did not get error:

```shell
python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input Spanish_N2SPNTLA_USX
```