### PR TITLE
Task-2190 error with aws-cli installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ FROM public.ecr.aws/docker/library/alpine:latest
 
 WORKDIR /app
 
-RUN apk update
-RUN apk add aws-cli ffmpeg jq mysql-client nodejs python3 py3-pip
+RUN apk update && \
+    apk add --no-cache ffmpeg jq mysql-client nodejs python3 py3-pip
 
 # --
 # To get past the "externally-managed-environment" error
@@ -29,7 +29,7 @@ RUN python -m venv $VIRTUAL_ENV
 RUN /bin/sh -c "source $VIRTUAL_ENV/bin/activate"
 # --
 
-RUN pip install boto3 pymysql pytz
+RUN pip install boto3 pymysql pytz awscli
 
 COPY --from=Sofria /app/sofria-cli ./sofria-cli
 


### PR DESCRIPTION
# Description
It is possible that the issue is related to apk, the package manager for Alpine Linux, which couldn't find the aws-cli package in its repositories. Therefore, aws-cli will be installed using Python pip instead of apk.

# How to test it
- I created the Docker image locally using the following command:
```shell
docker build . -t dbp-etl
```
- Then, I checked if the Docker image has correctly installed the AWS CLI using the following command and validated the outcome:
```shell
docker run --rm dbp-etl aws --version
```
- Outcome:
```shell
aws-cli/1.32.111 Python/3.12.3 Linux/6.8.0-76060800daily20240311-generic botocore/1.34.111
```