### PR TITLE
Task-2192 added logic to ignore inactive language records when trying…

### DIFF
--- a/load/UpdateDBPBiblesTable.py
+++ b/load/UpdateDBPBiblesTable.py
@@ -139,6 +139,9 @@ class UpdateDBPBiblesTable:
 		final = set()
 
 		for (_, languageRecord) in languageRecords:
+			if not languageRecord.IsActive():
+				continue
+
 			iso, langName, countryName = self.normalize_language_record(languageRecord)
 			result = self.languageCountryMap.get((iso, langName, countryName))
 
@@ -149,6 +152,9 @@ class UpdateDBPBiblesTable:
 
 		if len(final) == 0:
 			for (_, languageRecord) in languageRecords:
+				if not languageRecord.IsActive():
+					continue
+
 				iso, langName, _ = self.normalize_language_record(languageRecord)
 				result = self.languageMap1.get((iso, langName))
 
@@ -156,6 +162,9 @@ class UpdateDBPBiblesTable:
 					final.add(result)
 		if len(final) == 0:
 			for (_, languageRecord) in languageRecords:
+				if not languageRecord.IsActive():
+					continue
+
 				iso, langName, _ = self.normalize_language_record(languageRecord)
 				result = self.languageMap2.get((iso, langName))
 
@@ -163,12 +172,16 @@ class UpdateDBPBiblesTable:
 					final.add(result)
 		if len(final) == 0:
 			for (_, languageRecord) in languageRecords:
+				if not languageRecord.IsActive():
+					continue
+
 				iso, _, _ = self.normalize_language_record(languageRecord)
 				result = self.languageMap3.get(iso)
 
 				if result != None:
 					final.add(result)
 		if len(final) == 0:
+			iso, _, _ = self.normalize_language_record(languageRecord)
 			print("ERROR_01 ISO code of bibleId unknown", iso, bibleId)
 			return None
 		if len(final) > 1:


### PR DESCRIPTION
# Description
Added logic to ignore inactive language records when trying to get the language for a specific Bible ID.

# Task
[Bug 2192](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2192): uploader: ignore archived when evaluating bible/language match

# How test it
- I have used the following lpts-dbp.xml to test:
[lpts-dbp_small_xml.txt](https://github.com/faithcomesbyhearing/dbp-etl/files/15422250/lpts-dbp_small_xml.txt)

- If you run the following command you can see that it won't render the message: `WARN iso: eng | name: english (australian) | country: australia did not match with StockNumber: N1AUS/GNB`
```shell
python3 load/UpdateDBPBiblesTable.py test
```

- Outcome:
[log_update_bibles_language.txt](https://github.com/faithcomesbyhearing/dbp-etl/files/15422238/log_update_bibles_language.txt)
