### PR TITLE
Task-2222 Uploader: video timestamps are not inserted correctly

### DIFF
--- a/load/UpdateDBPVideoTables.py
+++ b/load/UpdateDBPVideoTables.py
@@ -96,7 +96,7 @@ class UpdateDBPVideoTables:
 
 		fileId = self.fileIdMap.get(m3u8Filename)
 		if fileId == None:
-			fileId = "@" + m3u8Filename.replace("-", "_")
+			fileId = "@" + SQLBatchExec.sanitize_value(m3u8Filename)
 		for line in m3u8Content.split("\n"):
 			if line.startswith("#EXT-X-STREAM-INF:"):
 				match = self.streamRegex.search(line)
@@ -139,7 +139,7 @@ class UpdateDBPVideoTables:
 
 		bandwidthId = self.dbpBandwidthIdMap.get(m3u8Filename)
 		if bandwidthId == None:
-			bandwidthId = "@" + m3u8Filename.replace("-", "_")
+			bandwidthId = "@" + SQLBatchExec.sanitize_value(m3u8Filename)
 		else:
 			bandwidthId = int(bandwidthId)
 		for line in m3u8Content.split("\n"):
@@ -197,24 +197,18 @@ if (__name__ == '__main__'):
 	dbOut = SQLBatchExec(config)
 	update = UpdateDBPFilesetTables(config, db, dbOut, languageReader)
 
-	filesetsVideoProccessed = []
-	for inp in InputFileset.upload:
-		hashId = update.processFileset(inp)
+	if len(InputFileset.upload) > 0:
+		filesetsVideoProccessed = []
+		for inp in InputFileset.upload:
+			hashId = update.processFileset(inp)
 
-		if inp.typeCode == "video":
-			filesetsVideoProccessed.append([inp.filesetPrefix, inp.filenames(), hashId])
+			if inp.typeCode == "video":
+				filesetsVideoProccessed.append([inp.filesetPrefix, inp.filenames(), hashId])
 
-	dbOut.displayStatements()
-	dbOut.displayCounts()
-	success = dbOut.execute("test-" + inp.filesetId)
-	db.close()
-
-	db = SQLUtility(config)
-	video = UpdateDBPVideoTables(config, db, dbOut)
-
-	if success and len(filesetsVideoProccessed) > 0:
-		for (filesetPrefix, filename, hashId) in filesetsVideoProccessed:
-			video.processFileset(filesetPrefix, filename, hashId)
+		if len(filesetsVideoProccessed) > 0:
+			video = UpdateDBPVideoTables(config, db, dbOut)
+			for (filesetPrefix, filename, hashId) in filesetsVideoProccessed:
+				video.processFileset(filesetPrefix, filename, hashId)
 
 		dbOut.displayStatements()
 		dbOut.displayCounts()


### PR DESCRIPTION
# Description
Fixed the logic for inserting bible_file_stream_ts records, the fix was related to correctly using the method to sanitize SQL variable names.

# Note
This issue was introduced after the following PR which was merged on May 13:
https://github.com/faithcomesbyhearing/dbp-etl/pull/134

The above code created the method `sanitize_value` to sanitize SQL variable names but I didn't extend this method to the logic to update the video timestamps.

# Task
[Bug 2222](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2222): Uploader: video timestamps are not inserted correctly

# How to test
- You should run the following command:
```shell
python3 load/UpdateDBPVideoTables.py test s3://etl-development-input/ "ENGESVP2DV"
```
- Outcome:
[Trans-test-video-ENGESVP2DV_sql.txt](https://github.com/user-attachments/files/16114560/Trans-test-video-ENGESVP2DV_sql.txt)
