### PR TITLE
Task-2101 support Blimp as system of record; activate via environment variable

### DIFF
--- a/lambda/prevalidate/Handler.py
+++ b/lambda/prevalidate/Handler.py
@@ -12,7 +12,7 @@ from PreValidate import *
 
 def handler(event, context):
 	bucket    = os.getenv("UPLOAD_BUCKET")
-	migration_stage = os.getenv("DATA_MODEL_MIGRATION_STAGE") # Should be "B" or "C"
+	migration_stage = os.getenv("DATA_MODEL_MIGRATION_STAGE", "B") # Should be "B" or "C"
 
 	directory = event["prefix"] # can be filesetId or lang_stockno_USX
 	filenames = event["files"] # Should be object keys
@@ -24,7 +24,7 @@ def handler(event, context):
 	session = boto3.Session()
 	s3Client = session.client("s3")
 	xmlFile = ""
-	if migration_stage != "Blimp":
+	if migration_stage != "BLIMP":
 		print("Copying lpts-dbp.xml...")
 		xmlFile = "/tmp/lpts-dbp.xml"
 		s3Client.download_file(bucket, "lpts-dbp.xml", xmlFile)

--- a/load/BlimpLanguageRecord.py
+++ b/load/BlimpLanguageRecord.py
@@ -1,0 +1,170 @@
+from LanguageReader import LanguageRecordInterface
+from BlimpLanguageService import getMediaByIdAndFormat 
+
+class BlimpLanguageRecord (LanguageRecordInterface):
+    propertiesName = {
+        "id": "Id",
+        "regStockNumber": "Reg_StockNumber",
+        "extent": "extent",
+        "country": "Country",
+        "iso": "ISO",
+        "langName": "LangName",
+        "dbpEquivalent": "DBP_Equivalent",
+        "licensor": "Licensor",
+        "copyrightc": "Copyrightc",
+        "copyrightp": "Copyrightp",
+        "volumneName": "Volumne_Name",
+        "dbpMobile": "DBPMobile",
+        "dbpWebHub": "DBPWebHub",
+        "mobileText": "MobileText",
+        "hubText": "HubText",
+        "apiDevText": "APIDevText",
+        "apiDevAudio": "APIDevAudio",
+        "ethName": "EthName",
+        "altName": "AltName",
+        "webHubVideo": "WebHubVideo",
+        "mobileVideo": "MobileVideo",
+        "copyrightVideo": "Copyright_Video",
+        "apiDevVideo": "APIDevVideo",
+        "status": "status",
+        "derivativeOf": "derivativeOf",
+        "orthography": "Orthography",
+    }
+
+    def __init__(self, record):
+        self.record = {
+            self.propertiesName['apiDevAudio']: "-1",
+            self.propertiesName['dbpMobile']: "-1",
+            self.propertiesName['dbpWebHub']: "-1",
+            self.propertiesName['apiDevText']: "-1",
+            self.propertiesName['mobileText']: "-1",
+            self.propertiesName['hubText']: "-1",
+            self.propertiesName['apiDevVideo']: "-1",
+            self.propertiesName['mobileVideo']: "-1",
+            self.propertiesName['webHubVideo']: "-1"
+        }
+
+        self.record.update(record)
+    
+    def DamIdList(self, typeCode):
+        return getMediaByIdAndFormat(self.derivativeOf(), typeCode)
+    
+    def ReduceTextList(self, damIdList):
+        damIdSet = set()
+        for (damId, index, status) in damIdList:
+            damIdOut = damId
+            damIdSet.add((damIdOut, index, status))
+        return damIdSet
+
+    def DamIdMap(self, typeCode, index):
+        return {
+            self.Id(): self.Status()
+        }
+
+    def Status(self):
+        return 'Live' if self.record.get(BlimpLanguageRecord.propertiesName['status']) == 'Complete' else self.record.get(BlimpLanguageRecord.propertiesName['status'])
+
+    def Id(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['id'])
+
+    def Reg_StockNumber(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['regStockNumber'])
+
+    def derivativeOf(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['derivativeOf'])
+
+    def LangName(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['langName'])
+
+    def ISO(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['iso'])
+
+    def Country(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['country'])
+
+    def DBP_Equivalent(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['dbpEquivalent'])
+
+    def DBP_EquivalentByIndex(self, index):
+        if index == 1:
+            return self.DBP_Equivalent()
+        else:
+            print("ERROR: DBP_Equivalent index must be 1, 2, or 3.")
+            sys.exit()
+
+    def Volumne_Name(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['volumneName'])
+
+    def Orthography(self, index):
+        return self.record.get(BlimpLanguageRecord.propertiesName['orthography'])
+
+    def EthName(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['ethName'])
+
+    def AltName(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['altName'])
+
+    def APIDevAudio(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['apiDevAudio'])
+
+    def DBPMobile(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['dbpMobile'])
+
+    def DBPWebHub(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['dbpWebHub'])
+
+    def APIDevText(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['apiDevText'])
+
+    def MobileText(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['mobileText'])
+
+    def HubText(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['hubText'])
+
+    def APIDevVideo(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['apiDevVideo'])
+
+    def MobileVideo(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['mobileVideo'])
+
+    def WebHubVideo(self):
+        return self.record.get(BlimpLanguageRecord.propertiesName['webHubVideo'])
+
+    def Licensor(self):
+        pass
+
+    def CoLicensor(self):
+        pass
+
+    def Copyrightc(self):
+        return 1
+    
+    def LicensorList(self):
+        return [1]
+
+    def HasLicensor(self, licensor):
+        pass
+
+    def HasCoLicensor(self, coLicensor):
+        pass
+
+    def CoLicensorList(self):
+        pass
+
+    def IsActive(self):
+        return self.Reg_Recording_Status() != "Discontinued" and self.Reg_Recording_Status() != "Inactive" and self.Reg_Recording_Status() != "Void"
+    
+    def Reg_Recording_Status(self):
+        return self.record.get("Reg_Recording_Status")
+    
+    def OTOrder(self):
+        return "Masoretic-Christian"
+    def NTOrder(self):
+        return "Traditional"
+
+    def Copyrightp(self):
+        return self.record.get("Copyrightp")
+
+    def Copyright_Video(self):
+        return self.record.get("Copyright_Video")

--- a/load/BlimpLanguageService.py
+++ b/load/BlimpLanguageService.py
@@ -1,0 +1,95 @@
+from SQLUtility import SQLUtility
+from Config import Config
+
+class BlimpLanguageService:
+    def __init__(self):
+        self.config = Config()
+    
+    def getMediaById(self, mediaId):
+        # self.config.setCurrentDatabaseDBName('LANGUAGE')
+        sql = SQLUtility(self.config)
+
+        return sql.select(
+            "SELECT bf.id,\
+                    bft.description,\
+                    bfc.bible_id AS bible_id\
+            FROM bible_filesets bf\
+            INNER JOIN bible_fileset_connections bfc ON bfc.hash_id = bf.hash_id\
+            INNER JOIN bible_fileset_tags bft on bft.hash_id = bf.hash_id\
+            WHERE bft.name = 'stock_no'\
+            AND bf.id = %s LIMIT 1\
+            ",
+            (mediaId)
+        )
+
+    def getMediaByStocknumber(self, stockNumber):
+        # self.config.setCurrentDatabaseDBName('LANGUAGE')
+        sql = SQLUtility(self.config)
+
+        return sql.select(
+            "SELECT bf.id,\
+                    bft.description,\
+                    bfc.bible_id AS bible_id,\
+                    bfm.name AS mode_type\
+            FROM bible_filesets bf\
+            INNER JOIN bible_fileset_connections bfc ON bfc.hash_id = bf.hash_id\
+            INNER JOIN bible_fileset_tags bft on bft.hash_id = bf.hash_id\
+            INNER JOIN bible_fileset_types bfty ON bfty.set_type_code = bf.set_type_code\
+            INNER JOIN bible_fileset_modes bfm ON bfm.id = bfty.mode_id\
+            WHERE bft.name = 'stock_no'\
+            AND bft.description = %s LIMIT 1\
+            ",
+            (stockNumber)
+        )
+
+        # return  result[0] if len(result) > 0 else None
+
+    def getMediaIdFromFilesetId(self, filesetId):
+        # self.config.setCurrentDatabaseDBName('BIBLEBRAIN')
+        sql = SQLUtility(self.config)
+
+        fileset = sql.select(
+            "SELECT bf.id,\
+                bfm.name AS mode_type\
+            FROM bible_filesets bf\
+            INNER JOIN bible_fileset_types bfty ON bfty.set_type_code = bf.set_type_code\
+            INNER JOIN bible_fileset_modes bfm ON bfm.id = bfty.mode_id\
+            WHERE bf.id = %s limit 1\
+            ",
+            (filesetId)
+        )
+
+        mediaId = None
+        modeType = None
+
+        for rowTuple in fileset:
+            mediaId = rowTuple[0]
+            modeType = rowTuple[1]
+
+        return (mediaId, modeType)
+
+def getMediaByIdAndFormat(bibleId, format):
+    config = Config()
+    # config.setCurrentDatabaseDBName('LANGUAGE')
+    sqlClient = SQLUtility(config)
+    derivativeOfmediaRecord = sqlClient.select(
+        "SELECT bf.id, 'Complete' as status\
+        FROM bible_filesets bf\
+        INNER JOIN bible_fileset_connections bfc ON bfc.hash_id = bf.hash_id\
+        INNER JOIN bible_fileset_types bft ON bft.set_type_code = bf.set_type_code\
+        INNER JOIN bible_fileset_modes bfm ON bfm.id = bft.mode_id\
+        WHERE CHAR_LENGTH(bf.id) > 6\
+        AND bfc.bible_id = %s\
+        AND bfm.name = %s\
+        ", (bibleId, format)
+    )
+
+    record = []
+    for row in derivativeOfmediaRecord:
+        damId = row[0]
+        status = row[1]
+        status = 'Live' if status == 'Complete' else '' 
+        # record.append((damId, 1, status, 'No Fieldname'))
+        record.append((damId, 1, status))
+
+    return record

--- a/load/BlimpLanguageServiceParse.py
+++ b/load/BlimpLanguageServiceParse.py
@@ -1,0 +1,42 @@
+from BlimpLanguageRecord import BlimpLanguageRecord as LanguageRecord;
+
+def parseMediaRow(rowTuple):
+    return {
+        LanguageRecord.propertiesName['id']: rowTuple[0],
+        LanguageRecord.propertiesName['regStockNumber']: rowTuple[1],
+        LanguageRecord.propertiesName['extent']: '',
+        LanguageRecord.propertiesName['country']: '',
+        LanguageRecord.propertiesName['iso']: '',
+        LanguageRecord.propertiesName['langName']: '',
+        LanguageRecord.propertiesName['dbpEquivalent']: rowTuple[2],
+        LanguageRecord.propertiesName['licensor']: '',
+        LanguageRecord.propertiesName['copyrightc']: '',
+        LanguageRecord.propertiesName['copyrightp']: '',
+        LanguageRecord.propertiesName['volumneName']: '',
+        LanguageRecord.propertiesName['dbpMobile']: '',
+        LanguageRecord.propertiesName['dbpWebHub']: '',
+        LanguageRecord.propertiesName['mobileText']: '',
+        LanguageRecord.propertiesName['hubText']: '',
+        LanguageRecord.propertiesName['apiDevText']: '',
+        LanguageRecord.propertiesName['apiDevAudio']: '',
+        LanguageRecord.propertiesName['webHubVideo']: '',
+        LanguageRecord.propertiesName['copyrightVideo']: '',
+        LanguageRecord.propertiesName['apiDevVideo']: '',
+        LanguageRecord.propertiesName['status']: 'Live',
+        LanguageRecord.propertiesName['derivativeOf']: rowTuple[2],
+        LanguageRecord.propertiesName['orthography']: '',
+        LanguageRecord.propertiesName['ethName']: '',
+        LanguageRecord.propertiesName['altName']: '',
+        "Text": rowTuple[0],
+        "Audio": rowTuple[0],
+        "Video": rowTuple[0],
+    }
+
+def parseResult(result):
+    newList = []
+
+    for rowTuple in result:
+        resultRow = parseMediaRow(rowTuple)
+        newList.append(LanguageRecord(resultRow))
+
+    return newList

--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -9,7 +9,6 @@
 # prior step are going to be processed.
 
 import os
-import json
 from datetime import datetime
 from Log import *
 from Config import *
@@ -18,7 +17,7 @@ from LanguageReader import *
 from SqliteUtility import *
 from PreValidate import *
 from AWSSession import *
-from UnicodeScript import *
+from LanguageReader import LanguageRecordInterface
 
 class InputFile:
 

--- a/load/InputProcessor.py
+++ b/load/InputProcessor.py
@@ -4,19 +4,17 @@
 # one or more InputFileset objects are created and returned.
 # 
 import os
-from datetime import datetime
 from Log import *
 from Config import *
-from InputFileset import *
+from InputFileset import InputFileset
 from RunStatus import *
 from PreValidate import *
 from AWSSession import *
-from UnicodeScript import *
 
 class InputProcessor:
 
 	## parse command line, and return [InputFileset]
-	def commandLineProcessor(config, s3Client, languageReader):
+	def commandLineProcessor(config, s3Client, languageReader=None):
 		if len(sys.argv) < 4:
 			print("FATAL command line parameters: config_profile  s3://bucket|localPath  path_list ")
 			sys.exit()

--- a/load/LanguageReader.py
+++ b/load/LanguageReader.py
@@ -105,7 +105,9 @@ class LanguageRecordInterface(ABC):
     # from damId: TNKWBTN1ET to text damId: TNKWBTN_ET
     @staticmethod
     def transformToTextId(id):
-        return id[:7] + "_" + id[8:]
+        if id != None:
+            return id[:7] + "_" + id[8:]
+        return ""
 
     @staticmethod
     def GetFilesetIdLen10(filesetId):

--- a/load/LanguageReaderCreator.py
+++ b/load/LanguageReaderCreator.py
@@ -1,31 +1,34 @@
 from LPTSExtractReader import LPTSExtractReader
-from StageCLanguageReader import *
-
+from StageCLanguageReader import StageCLanguageReader
+from BlimpLanguageReader import BlimpLanguageReader
+from typing import Union
 
 class LanguageReaderCreator:
+	def __init__(self, stage: str = "B"):
+		self.stage = stage
+		self.stage_map = {
+			"B": LPTSExtractReader,
+			"C": StageCLanguageReader,
+			"BLIMP": BlimpLanguageReader
+		}
 
-    def __init__(self, stage = "B"):
-        self.stage = stage
-    
+	def create(self, lpts_xml_path: Union[str, None] = None):
+		print(f"migration stage: [{self.stage}]")
+		reader_class = self.stage_map.get(self.stage)
+		if not reader_class:
+			raise ValueError(f"Unrecognized stage: {self.stage}")
+		if self.stage == "B":
+			return reader_class(lpts_xml_path)
+		return reader_class()
 
-    def create(self, lpts_xml_path = None):
-        print("migration stage: [%s]" % self.stage)
+if __name__ == '__main__':
+	from Config import Config
+	import os
 
-        if (self.stage == "B"):
-            return LPTSExtractReader(lpts_xml_path)
-        elif (self.stage == "C"):
-            return StageCLanguageReader()
-        elif (self.stage == "BLIMP"):
-            return BlimpLanguageReader() # FIXME(2101)
-        else:
-            print ("unrecognized stage: ", self.stage)
+	config = Config()
+	migration_stage = os.getenv("DATA_MODEL_MIGRATION_STAGE", "B")
+	lpts_xml = config.filename_lpts_xml if migration_stage == "B" else ""
 
-
-if (__name__ == '__main__'):
-    from Config import *    
-    config = Config()
-    migration_stage = os.getenv("DATA_MODEL_MIGRATION_STAGE") # Should be "B" or "C"
-    migration_stage = migration_stage if migration_stage != None else "B"
-    languageReader = LanguageReaderCreator(migration_stage).create(config.filename_lpts_xml)
-    results = languageReader.getByStockNumber("N1SPA/PDT")
-    print("Reg_StockNumber [%s]" % results.Reg_StockNumber())
+	languageReader = LanguageReaderCreator(migration_stage).create(lpts_xml)
+	results = languageReader.getByStockNumber("N1SPA/PDT")
+	print("Reg_StockNumber [%s]" % results.Reg_StockNumber())

--- a/load/Log.py
+++ b/load/Log.py
@@ -1,6 +1,5 @@
 # This class collects and reports error messages
 
-from datetime import datetime
 from Config import *
 from DBPRunFilesS3 import *
 
@@ -85,6 +84,9 @@ class Log:
 
 	def missingBibleIds(self):
 		self.messages.append((Log.EROR, "bibleId is not in LPTS."))
+
+	def missingBibleIdConnection(self, filesetId):
+		self.messages.append((Log.EROR, "FilesetId: %s is not related with a specific bible." % (filesetId)))
 
 	def missingFilesetIds(self):
 		self.messages.append((Log.EROR, "filesetId is not in LPTS record."))

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -13,7 +13,7 @@ from TextStockNumberProcessor import *
 
 class PreValidate:
 
-	def __init__(self, languageReader, s3Client, bucket):
+	def __init__(self, languageReader=None, s3Client=None, bucket=""):
 		self.languageReader = languageReader
 		self.messages = {}	
 		self.s3Client = s3Client
@@ -25,7 +25,8 @@ class PreValidate:
 	# there is no bucket involved, since the code has not been uploaded yet
 	def validateLambda(self, directoryName, filenames, stocknumberFileContentsString = None):
 		result = None
-		textStockNumberProcessor = TextStockNumberProcessor() # FIXME(2101) - self.languageReader is not needed for Lambda pre-validation. not sure if this is legal, but this is the intent
+		# TextStockNumberProcessor will be invoked but the variable self.languageReader could be None
+		textStockNumberProcessor = TextStockNumberProcessor(self.languageReader)
 		(stockNumberResultList, textProcessingErrors) = textStockNumberProcessor.validateTextStockNumbersFromLambda(stocknumberFileContentsString, directoryName, filenames)
 		self.addErrorMessages("text-processing", textProcessingErrors)
 		if (self.hasErrors()):
@@ -84,15 +85,13 @@ class PreValidate:
 		stockNumSet = set()
 		mediaSet = set()
 		bibleIdSet = set()
-		for (languageRecord, status, fieldName) in results:
+		for (languageRecord, _, fieldName) in results:
 			if not languageRecord.IsActive():
 				continue
 			stockNum = languageRecord.Reg_StockNumber() 
 			if stockNum != None:
 				stockNumSet.add(stockNum)
 			damId = languageRecord.record.get(fieldName)
-
-			dbpFilesetId = filesetId
 			if "Audio" in fieldName:
 				media = "audio"
 			elif "Text" in fieldName:
@@ -191,9 +190,9 @@ class PreValidate:
 
 ## System Test for PreValidate,testing the validateDBPETL entry point (see PreValidateLambdaHandlerStub for the lambda entry point system test)
 if (__name__ == "__main__"):
-	import boto3
-	from Config import *
-	from AWSSession import *
+	import sys
+	from Config import Config
+	from AWSSession import AWSSession
 	from LanguageReaderCreator import LanguageReaderCreator	
 
 	if len(sys.argv) < 2:
@@ -203,7 +202,7 @@ if (__name__ == "__main__"):
 	location = "s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r"
 	prefix = "2022-03-25-16-14-34"
 	directoryName = "Abidji_N2ABIWBT_USX"
-	migration_stage = os.getenv("DATA_MODEL_MIGRATION_STAGE") # Should be "B" or "C"
+	migration_stage = os.getenv("DATA_MODEL_MIGRATION_STAGE", "B")
 
 	if len(sys.argv) > 2:
 		location = sys.argv[2][:-1] if sys.argv[2].endswith("/") else sys.argv[2]
@@ -222,7 +221,8 @@ if (__name__ == "__main__"):
 
 	config = Config()
 	AWSSession.shared()
-	languageReader = LanguageReaderCreator(migration_stage).create(config.filename_lpts_xml)
+	lpts_xml = config.filename_lpts_xml if migration_stage == "B" else ""
+	languageReader = LanguageReaderCreator(migration_stage).create(lpts_xml)
 	s3Client = AWSSession.shared().s3Client
 
 	preValidate = PreValidate(languageReader, s3Client, location) 
@@ -241,3 +241,5 @@ if (__name__ == "__main__"):
 
 # python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-03-25-16-14-34 Spanish_N2SPNTLA_USX
 # python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-09-27-13-48-13 ENGESVO2ET
+
+# dbp-etl-dev s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r/2022-10-17-18-49-35/Spanish_N2SPNTLA_USX/

--- a/load/S3Utility.py
+++ b/load/S3Utility.py
@@ -78,7 +78,7 @@ class S3Utility:
 if (__name__ == '__main__'):
 	from SQLUtility import *
 	from InputProcessor import *
-	from UpdateDBPTextFilesets import *
+	from UpdateDBPTextFilesets import UpdateDBPTextFilesets
 	from LanguageReaderCreator import LanguageReaderCreator	
 
 	config = Config.shared()
@@ -96,7 +96,7 @@ if (__name__ == '__main__'):
 				filePath = inp.downloadFiles()
 			else:
 				filePath = inp.fullPath()
-			errorTuple = texts.validateFileset("text_plain", inp.bibleId, inp.filesetId, inp.languageRecord, inp.index, filePath)
+			errorTuple = texts.validateFileset("text_plain", inp.filesetId, inp.languageRecord, inp.index)
 			if errorTuple != None:
 				logger = Log.getLogger(inp.filesetId)
 				logger.messageTuple(errorTuple)

--- a/load/TextStockNumberProcessor.py
+++ b/load/TextStockNumberProcessor.py
@@ -1,12 +1,12 @@
 
+import os
 from botocore.exceptions import ClientError
 from PreValidateResult import *
-from UnicodeScript import *
 
 class TextStockNumberProcessor:
 
-	def __init__(self):
-		self.unicodeScript = UnicodeScript()
+	def __init__(self, languageReader=None):
+		self.languageReader = languageReader
 		self.errors = [] # array of strings
 		self.OT = { "GEN", "EXO", "LEV", "NUM", "DEU", "JOS", "JDG", "RUT", "1SA", "2SA", "1KI", "2KI", "1CH", "2CH", 
 					"EZR", "NEH", "EST", "JOB", "PSA", "PRO", "ECC", "SNG", "ISA", "JER", "LAM", "EZK", "DAN", "HOS", 
@@ -14,10 +14,6 @@ class TextStockNumberProcessor:
 		self.NT = { "MAT", "MRK", "LUK", "JHN", "ACT", "ROM", "1CO", "2CO", "GAL", "EPH", "PHP", "COL", "1TH", "2TH", 
 					"1TI", "2TI", "TIT", "PHM", "HEB", "JAS", "1PE", "2PE", "1JN", "2JN", "3JN", "JUD", "REV" }			
 
-	def __init__(self, languageReader):
-		self.languageReader = languageReader
-		self.__init__();
-	
 
 	def validateTextStockNumbersFromLambda(self, stocknumberFileContentsString, directoryName, filenames):
 		resultList = []
@@ -115,7 +111,6 @@ class TextStockNumberProcessor:
 		result = {}
 		textDamIds = lptsRecord.DamIdList("text")
 		textDamIds = lptsRecord.ReduceTextList(textDamIds)
-		#print("damIds", textDamIds)
 		for (damId, index, status) in textDamIds:
 			scope = damId[6]
 			script = lptsRecord.Orthography(index)
@@ -137,7 +132,7 @@ class TextStockNumberProcessor:
 		if len(bookIdsFound) >= len(bookIdSet):
 			if scopeMap.get(scope) != None:
 				for (damId, index, script) in scopeMap.get(scope):
-					if actualScript == None or self.unicodeScript.matchScripts(actualScript, script):
+					if actualScript == None:
 						filenameList = self._getFilenameList(scope, bookIdsFound, bookIdMap)
 						result = PreValidateResult(lptsRecord, damId + "-usx", damId, "text", index, filenameList)
 				if result == None:
@@ -150,7 +145,7 @@ class TextStockNumberProcessor:
 		elif len(bookIdsFound) > 0:
 			if scopeMap.get("P") != None:
 				for (damId, index, script) in scopeMap.get("P"):
-					if actualScript == None or self.unicodeScript.matchScripts(actualScript, script):
+					if actualScript == None:
 						filenameList = self._getFilenameList(scope, bookIdsFound, bookIdMap)
 						result = PreValidateResult(lptsRecord, damId + "-usx", damId, "text", index, filenameList)
 				if result == None:
@@ -246,12 +241,28 @@ class TextStockNumberProcessor:
 
 
 	def getSampleUnicodeTextFromS3(self, s3Client, bucket, fullPath):
-		filenames = self.unicodeScript.getFilenames(s3Client, bucket, fullPath)
-		sampleText =  self.unicodeScript.readObject(s3Client, bucket, fullPath + "/" + filenames[0]) if len(filenames) > 0 else None
-		if sampleText != None:
-			textArray = self.unicodeScript.parseXMLStrings(sampleText)
-			#print("sample", "".join(textArray[:40]))
-			(actualScript, matchPct) = self.unicodeScript.findScript(textArray)
+		filenames = self.getFilenames(s3Client, bucket, fullPath)
+		return (filenames, None)
+
+	def getFilenames(self, s3Client, location, filesetPath):
+		results = []
+		if not location.startswith("s3://"):
+			pathname = location + os.sep + filesetPath
+			if os.path.isdir(pathname):
+				for filename in [f for f in os.listdir(pathname) if not f.startswith('.')]:
+					if (filename.endswith(".usx") and not filename.startswith(".")):
+						results.append(filename)
+			else:
+				self.errors.append("ERROR: Invalid pathname %s" % (pathname,))
 		else:
-			actualScript = None
-		return (filenames, actualScript)
+			bucket = location[5:]
+			request = { 'Bucket': bucket, 'MaxKeys': 1000, 'Prefix': filesetPath + "/" }
+			response = s3Client.list_objects_v2(**request)
+			for item in response.get('Contents', []):
+				objKey = item.get('Key')
+				filename = objKey[len(filesetPath) + 1:]
+				if (filename.endswith(".usx") and not filename.startswith(".")):
+					results.append(filename)
+			if len(results) == 0:
+				self.errors.append("ERROR: Invalid bucket %s or prefix %s/" % (bucket, filesetPath))
+		return results


### PR DESCRIPTION
# Description
Support Blimp as the system of record for BibleBrain data by setting the environment variable DATA_MODEL_MIGRATION_STAGE to BLIMP. Ensured the code works before Blimp becomes the system of record.

# Note
- Created a new [load/BlimpLanguageReader.py](https://github.com/faithcomesbyhearing/dbp-etl/compare/blimp...task-2101-support-blimp-system-record?expand=1#diff-95ea1b21a4bf737e4e1d09e2a50cb69a1b5065a90b56f721a2e79135e2077e05)
- Removed all Orthography constraints
- Load content proces will always point to BLIMP stage because the lpts.xml should be used
- Add constraint in [load/Validate.py](https://github.com/faithcomesbyhearing/dbp-etl/compare/blimp...task-2101-support-blimp-system-record?expand=1#diff-d1a2030b8c842850da3772bec71bf13fb640ca3b151227b1350f282ae29f7003) to check if the relationship between a fileset and a Bible exists.

# Task
[User Story 2101](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2101): uploader:  support Blimp as system of record; activate via environment variable

# How to test
- I have run the command with the migration stage = "B"
```shell
# Load xml
python3 load/DBPLoadController.py test

# Load content but the xml is not used
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVP2DV
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVN2DA

```
- I have run the command with the migration stage = "BLIMP"
```shell
# Try to load xml but it must return error: "cannot process because Blimp is the system of record"
python3 load/DBPLoadController.py test

# Load content using the biblebrain database
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVP2DV
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVO2ET
python3 load/DBPLoadController.py test s3://etl-development-input ENGESVN2DA

```
- I have run the command with the migration  stage = "B" and "BLIMP"
```
python3 load/Validate.py test s3://etl-development-input ENGESVO2ET
python3 load/UpdateDBPTextFilesets.py test s3://etl-development-input ENGESVO2ET
python3 load/PreValidateLambdaHandlerStub.py test text OT
python3 load/PreValidateLambdaHandlerStub.py test text OT fail
python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-09-27-13-48-13 ENGESVO2ET B
python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-10-17-18-49-35 Spanish_N2SPNTLA_USX BLIMP

```