### PR TITLE
Task-2360 Update BlimpLanguageRecord.py to implement the copyright an…

### DIFF
--- a/load/BlimpLanguageRecord.py
+++ b/load/BlimpLanguageRecord.py
@@ -1,5 +1,5 @@
 from LanguageReader import LanguageRecordInterface
-from BlimpLanguageService import getMediaByIdAndFormat 
+from BlimpLanguageService import getMediaByIdAndFormat, getLicensorsByFilesetId, getCopyrightByFilesetId
 
 class BlimpLanguageRecord (LanguageRecordInterface):
     propertiesName = {
@@ -139,10 +139,14 @@ class BlimpLanguageRecord (LanguageRecordInterface):
         pass
 
     def Copyrightc(self):
-        return 1
-    
+        # Check the copyright of the primary fileset
+        copyrightList = getCopyrightByFilesetId(self.Id())
+        return copyrightList[0] if len(copyrightList) > 0 else None
+
     def LicensorList(self):
-        return [1]
+        # Check the licensors of the primary fileset
+        licensorList = getLicensorsByFilesetId(self.Id())
+        return licensorList if len(licensorList) > 0 else None
 
     def HasLicensor(self, licensor):
         pass
@@ -165,11 +169,12 @@ class BlimpLanguageRecord (LanguageRecordInterface):
         return "Traditional"
 
     def Copyrightp(self):
-        return self.record.get("Copyrightp")
+        # It can use Copyrightc because, in Blimp, the relationship between the fileset (text, audio and video) and the copyright is stored in the entity
+        return self.Copyrightc()
 
     def Copyright_Video(self):
-        return self.record.get("Copyright_Video")
-
+        # It can use Copyrightc because, in Blimp, the relationship between the fileset (text, audio and video) and the copyright is stored in the entity
+        return self.Copyrightc()
 
     def StockNumberByFilesetIdAndType(self, filesetId, typeCode):
         damIds = self.DamIdList(typeCode)

--- a/load/BlimpLanguageService.py
+++ b/load/BlimpLanguageService.py
@@ -100,3 +100,51 @@ def getMediaByIdAndFormat(bibleId, format):
         record.append((damId, 1, status))
 
     return record
+
+def getLicensorsByFilesetId(filesetId):
+    config = Config()
+    sqlClient = SQLUtility(config)
+
+    licensors = sqlClient.select(
+        "SELECT organizations.id, organization_translations.name, organization_logos.url AS logo\
+        FROM organizations\
+        INNER JOIN organization_translations ON organization_translations.organization_id = organizations.id\
+        LEFT JOIN organization_logos ON organization_logos.organization_id = organizations.id AND organization_logos.icon = false\
+        INNER JOIN bible_fileset_copyright_organizations ON bible_fileset_copyright_organizations.organization_id = organizations.id\
+        INNER JOIN bible_filesets ON bible_filesets.hash_id = bible_fileset_copyright_organizations.hash_id\
+        WHERE organization_translations.language_id = 6414\
+        AND bible_fileset_copyright_organizations.organization_role = 2\
+        AND bible_filesets.id = %s\
+        GROUP BY organizations.id, organization_translations.name, organization_logos.url\
+        ", (filesetId)
+    )
+
+    records = []
+    for row in licensors:
+        organizationId = row[0]
+        organizationName = row[1]
+        organizationLogo = row[2]
+        records.append((organizationId, organizationName, organizationLogo))
+
+    return records
+
+def getCopyrightByFilesetId(filesetId):
+    config = Config()
+    sqlClient = SQLUtility(config)
+
+    licensors = sqlClient.select(
+        "SELECT bible_fileset_copyrights.copyright, bible_fileset_copyrights.copyright_date, bible_fileset_copyrights.copyright_description\
+        FROM bible_fileset_copyrights\
+        INNER JOIN bible_filesets ON bible_filesets.hash_id = bible_fileset_copyrights.hash_id\
+        AND bible_filesets.id = %s\
+        ", (filesetId)
+    )
+
+    records = []
+    for row in licensors:
+        copyright = row[0]
+        copyrightDate = row[1]
+        copyrightDescription = row[2]
+        records.append((copyright, copyrightDate, copyrightDescription))
+
+    return records

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -260,3 +260,7 @@ if (__name__ == "__main__"):
 # python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2022-09-27-13-48-13 ENGESVO2ET
 
 # dbp-etl-dev s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r/2022-10-17-18-49-35/Spanish_N2SPNTLA_USX/
+
+# python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2023-07-10-15-38-20 JAAJARN2DA/
+# python3 load/PreValidate.py test s3://etl-development-input/ "" TGKWBTP2DV
+# python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2024-07-24-17-15-56 Spanish_N2SPNBDA_USX


### PR DESCRIPTION
# Description
Update BlimpLanguageRecord.py to implement the copyright and licensor methods, which will retrieve the content from the Biblebrain database.

# Task
[User Story 2360](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2360): uploader: prevalidate should fail if no licensor linkage

# How to test
1. The following command has been executed, and the copyright and licensor do not exist:

`````shell
## command
python3 load/PreValidate.py test s3://etl-development-input/ "" TGKWBTP2DV

## Outcome
location [s3://etl-development-input], prefix [], directoryName [TGKWBTP2DV] migration [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
AWSSession. assume role arn: arn:aws:iam::869054869504:role/dbp-etl-dev
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LanguageReader requested: [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
No stocknumber.txt file found. bucket [etl-development-input], fullPath: [TGKWBTP2DV], key [TGKWBTP2DV/stocknumber.txt]
PreValidate.validateDBPETL. after call to getStocknumberStringFromS3. stocknumberString: None 
TextStocknumberProcessor.validateTextStockNumbersFromController entry... stocknumberFileContentsString: None, directoryName: TGKWBTP2DV, location: s3://etl-development-input, fullPath TGKWBTP2DV 
TextStocknumberProcessor.getStockNumberList, returning stockNumberList from parsing Directory name: TGKWBTP2DV, stocknumberList: None
PreValidate.validateDBPETL. line 66. stocknumberResultList  was not >0.. validate filesetid from directoryName: TGKWBTP2DV
PreValidate.validateFilesetId. directoryName: TGKWBTP2DV, filesetId: TGKWBTP2DV, filesetId1: TGKWBTP2DV 
Database 'dbp_2024_08_15' is opened.
Database 'dbp_2024_08_15' is opened.
PreValidate.validateFilesetId. damId: TGKWBTP2DV check1: results: {(<BlimpLanguageRecord.BlimpLanguageRecord object at 0x7e5d58285000>, 'Live', 'Video')}
PreValidate.validateFilesetId. didn't return error.. languageRecord: <BlimpLanguageRecord.BlimpLanguageRecord object at 0x7e5d58285000>, fieldName: Video
PreValidate.validateFilesetId. regStockNumber: N1TGK/WBT
PreValidate.validateFilesetId. damId: TGKWBTP2DV
PreValidate.validateFilesetId. index: 1, bibleId: TGKWBT
PreValidate.validateFilesetId. mediaSet and bibleIdSet not empty. return PreValidateResult..
PreValidate.validateDBPETL. result from validateFilesetId: <PreValidateResult.PreValidateResult object at 0x7e5d58284d30>
PreValidate.validateDBPETL. result from validateFilesetId was not empty, so validateLPTS ???
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
validate failed: {'TGKWBTP2DV': ['LPTS N1TGK/WBT field Copyrightc is required.', 'LPTS N1TGK/WBT field Copyrightp is required.', 'LPTS N1TGK/WBT field Copyright_Video is required.', 'LPTS N1TGK/WBT field Licensor is required.']}
`````

2. You can run the following command, and it will execute successfully:

- Audio
````shell
## python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2024-07-31-21-11-50 MMYWYIN2DA

## Outcome
location [s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r], prefix [2024-07-31-21-11-50], directoryName [MMYWYIN2DA] migration [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
AWSSession. assume role arn: arn:aws:iam::869054869504:role/dbp-etl-dev
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LanguageReader requested: [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
No stocknumber.txt file found. bucket [dbp-etl-upload-dev-ya1mbvdty8tlq15r], fullPath: [2024-07-31-21-11-50/MMYWYIN2DA], key [2024-07-31-21-11-50/MMYWYIN2DA/stocknumber.txt]
PreValidate.validateDBPETL. after call to getStocknumberStringFromS3. stocknumberString: None 
TextStocknumberProcessor.validateTextStockNumbersFromController entry... stocknumberFileContentsString: None, directoryName: MMYWYIN2DA, location: s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r, fullPath 2024-07-31-21-11-50/MMYWYIN2DA 
TextStocknumberProcessor.getStockNumberList, returning stockNumberList from parsing Directory name: MMYWYIN2DA, stocknumberList: None
PreValidate.validateDBPETL. line 66. stocknumberResultList  was not >0.. validate filesetid from directoryName: MMYWYIN2DA
PreValidate.validateFilesetId. directoryName: MMYWYIN2DA, filesetId: MMYWYIN2DA, filesetId1: MMYWYIN2DA 
Database 'dbp_2024_08_15' is opened.
Database 'dbp_2024_08_15' is opened.
PreValidate.validateFilesetId. damId: MMYWYIN2DA check1: results: {(<BlimpLanguageRecord.BlimpLanguageRecord object at 0x706c25569000>, 'Live', 'Audio')}
PreValidate.validateFilesetId. didn't return error.. languageRecord: <BlimpLanguageRecord.BlimpLanguageRecord object at 0x706c25569000>, fieldName: Audio
PreValidate.validateFilesetId. regStockNumber: N2MMY/WYI
PreValidate.validateFilesetId. damId: MMYWYIN2DA
PreValidate.validateFilesetId. index: 1, bibleId: MMYWYI
PreValidate.validateFilesetId. mediaSet and bibleIdSet not empty. return PreValidateResult..
PreValidate.validateDBPETL. result from validateFilesetId: <PreValidateResult.PreValidateResult object at 0x706c25568dc0>
PreValidate.validateDBPETL. result from validateFilesetId was not empty, so validateLPTS ???
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Validation passed
````
- Text
````shell
## python3 load/PreValidate.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r 2024-10-30-21-47-44 "Arrente, Eastern_P2AERWYI_USX"

## Outcome
location [s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r], prefix [2024-10-30-21-47-44], directoryName [Arrente, Eastern_P2AERWYI_USX] migration [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
AWSSession. assume role arn: arn:aws:iam::869054869504:role/dbp-etl-dev
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LanguageReader requested: [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
No stocknumber.txt file found. bucket [dbp-etl-upload-dev-ya1mbvdty8tlq15r], fullPath: [2024-10-30-21-47-44/Arrente, Eastern_P2AERWYI_USX], key [2024-10-30-21-47-44/Arrente, Eastern_P2AERWYI_USX/stocknumber.txt]
PreValidate.validateDBPETL. after call to getStocknumberStringFromS3. stocknumberString: None 
TextStocknumberProcessor.validateTextStockNumbersFromController entry... stocknumberFileContentsString: None, directoryName: Arrente, Eastern_P2AERWYI_USX, location: s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r, fullPath 2024-10-30-21-47-44/Arrente, Eastern_P2AERWYI_USX 
TextStocknumberProcessor.getStockNumberList, returning stockNumberList from parsing Directory name: Arrente, Eastern_P2AERWYI_USX, stocknumberList: ['P2AER/WYI']
TextStocknumberProcessor.validateTextStockNumbersFromController stocknumberList is not empty: ['P2AER/WYI']
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
TextStocknumberProcessor._findDamIdScopeMap.. damId (should be max 10 characters... ): AERWYIP_ET, index: 1
TextStocknumberProcessor._findDamIdScopeMap.. damId (should be max 10 characters... ): AERWYIN_ET, index: 1
TextStocknumberProcessor.matchFilesToDamId. stocknumber: P2AER/WYI, scope: N, lptsRecord: <BlimpLanguageRecord.BlimpLanguageRecord object at 0x75c32f5c4f40>
TextStocknumberProcessor.matchFilesToDamId, line 143. damId: AERWYIN_ET, index: 1
TextStocknumberProcessor.matchFilesToDamId. stocknumber: P2AER/WYI, scope: O, lptsRecord: <BlimpLanguageRecord.BlimpLanguageRecord object at 0x75c32f5c4f40>
TextStocknumberProcessor.matchFilesToDamId, line 143. damId: AERWYIP_ET, index: 1
PreValidate.validateDBPETL. line 62. stocknumberResultList > 0.. value: <PreValidateResult.PreValidateResult object at 0x75c32f5c6260>
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Validation passed
````
- Video
````shell
## python3 load/PreValidate.py test s3://etl-development-input/ "" TGKWBTP2DV

## Outcome
location [s3://etl-development-input], prefix [], directoryName [TGKWBTP2DV] migration [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
AWSSession. assume role arn: arn:aws:iam::869054869504:role/dbp-etl-dev
Created role arn:aws:iam::869054869504:role/dbp-etl-dev based session for s3.
LanguageReader requested: [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
No stocknumber.txt file found. bucket [etl-development-input], fullPath: [TGKWBTP2DV], key [TGKWBTP2DV/stocknumber.txt]
PreValidate.validateDBPETL. after call to getStocknumberStringFromS3. stocknumberString: None 
TextStocknumberProcessor.validateTextStockNumbersFromController entry... stocknumberFileContentsString: None, directoryName: TGKWBTP2DV, location: s3://etl-development-input, fullPath TGKWBTP2DV 
TextStocknumberProcessor.getStockNumberList, returning stockNumberList from parsing Directory name: TGKWBTP2DV, stocknumberList: None
PreValidate.validateDBPETL. line 66. stocknumberResultList  was not >0.. validate filesetid from directoryName: TGKWBTP2DV
PreValidate.validateFilesetId. directoryName: TGKWBTP2DV, filesetId: TGKWBTP2DV, filesetId1: TGKWBTP2DV 
Database 'dbp_2024_08_15' is opened.
Database 'dbp_2024_08_15' is opened.
PreValidate.validateFilesetId. damId: TGKWBTP2DV check1: results: {(<BlimpLanguageRecord.BlimpLanguageRecord object at 0x79839dfc5000>, 'Live', 'Video')}
PreValidate.validateFilesetId. didn't return error.. languageRecord: <BlimpLanguageRecord.BlimpLanguageRecord object at 0x79839dfc5000>, fieldName: Video
PreValidate.validateFilesetId. regStockNumber: N1TGK/WBT
PreValidate.validateFilesetId. damId: TGKWBTP2DV
PreValidate.validateFilesetId. index: 1, bibleId: TGKWBT
PreValidate.validateFilesetId. mediaSet and bibleIdSet not empty. return PreValidateResult..
PreValidate.validateDBPETL. result from validateFilesetId: <PreValidateResult.PreValidateResult object at 0x79839dfc4d30>
PreValidate.validateDBPETL. result from validateFilesetId was not empty, so validateLPTS ???
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: PreValidate.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Validation passed

````