### PR TITLE
Task-2368 added a new capability to associate the licensor and copyri…

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -255,6 +255,14 @@ class InputFileset:
 		else:
 			return None
 
+	def isDerivedFileset(self):
+		if self.typeCode == "text":
+			if self.filesetId.endswith("-usx") or self.filesetId.endswith("-html") or self.filesetId.endswith("-json"):
+				return True
+		elif self.typeCode == "audio" and self.filesetId.endswith("-opus16"):
+				return True
+
+		return False
 
 	def isMP3Fileset(self):
 		for file in self.files:

--- a/load/UpdateDBPLicensorTables.py
+++ b/load/UpdateDBPLicensorTables.py
@@ -1,0 +1,97 @@
+# UpdateDBPLicensorTables.py
+#
+# This program inserts and replaces records in the DBP database
+# 1. bible_fileset_copyright_organizations
+# 2. bible_fileset_copyrights
+#
+# 1. Insert the transactions one fileset at a time.
+
+from Config import Config
+from SQLUtility import SQLUtility
+from SQLBatchExec import SQLBatchExec
+from BlimpLanguageService import getLicensorsByFilesetId, getCopyrightByFilesetId
+
+class UpdateDBPLicensorTables:
+
+	def __init__(self, db, dbOut):
+		self.db = db
+		self.dbOut = dbOut
+
+	def processFileset(self, primaryFilesetId, derivedHashId):
+		
+		inserts = []					
+		tableName = "bible_fileset_copyright_organizations"
+		pkeyNames = ("hash_id", "organization_role")
+		attrNames = ("organization_id",)
+
+		licensors = getLicensorsByFilesetId(primaryFilesetId)
+
+		for (organizationId, _, _) in licensors:
+			orgIdExisting = self.db.selectScalar("\
+				SELECT organizations.id\
+				FROM organizations\
+				INNER JOIN bible_fileset_copyright_organizations ON bible_fileset_copyright_organizations.organization_id = organizations.id\
+				WHERE bible_fileset_copyright_organizations.organization_role = 2\
+				AND bible_fileset_copyright_organizations.hash_id = %s\
+				AND organizations.id = %s", (derivedHashId, organizationId)
+			)
+
+			if orgIdExisting == None:
+				inserts.append((organizationId, derivedHashId, 2))
+
+
+		self.dbOut.insert(tableName, pkeyNames, attrNames, inserts)
+
+		inserts = []
+		updates = []
+		tableName = "bible_fileset_copyrights"
+		pkeyNames = ("hash_id",)
+		attrNames = ("copyright_date", "copyright", "copyright_description")
+
+		copyrights = getCopyrightByFilesetId(primaryFilesetId)
+
+		for (copyright, copyrightDate, copyrightDescription) in copyrights:
+			hashIdExisting = self.db.selectScalar("\
+				SELECT bible_fileset_copyrights.copyright,\
+					bible_fileset_copyrights.copyright_date,\
+					bible_fileset_copyrights.copyright_description,\
+					bible_fileset_copyrights.open_access\
+				FROM bible_fileset_copyrights\
+				WHERE bible_fileset_copyrights.hash_id = %s", (derivedHashId,)
+			)
+
+			if hashIdExisting == None:
+				inserts.append((copyrightDate, copyright, copyrightDescription, derivedHashId))
+			else:
+				updates.append((copyrightDate, copyright, copyrightDescription, derivedHashId))
+
+		self.dbOut.insert(tableName, pkeyNames, attrNames, inserts)
+		self.dbOut.updateCol(tableName, pkeyNames, updates)
+
+		return True
+
+## Unit Test
+if (__name__ == '__main__'):
+	from LanguageReaderCreator import LanguageReaderCreator	
+	from InputFileset import InputFileset
+	from DBPLoadController import DBPLoadController
+	from UpdateDBPFilesetTables import UpdateDBPFilesetTables
+	from InputProcessor import InputProcessor
+	from AWSSession import AWSSession
+
+	config = Config.shared()
+	languageReader = LanguageReaderCreator("BLIMP").create("")
+	filesets = InputProcessor.commandLineProcessor(config, AWSSession.shared().s3Client, languageReader)
+	db = SQLUtility(config)
+	ctrl = DBPLoadController(config, db, languageReader)	
+	ctrl.validate(filesets)
+	ctrl.upload(InputFileset.upload)
+
+	dbOut = SQLBatchExec(config)
+	update = UpdateDBPFilesetTables(config, db, dbOut, languageReader)
+	for inp in InputFileset.upload:
+		hashId = update.processFileset(inp)
+
+		dbOut.displayStatements()
+		dbOut.displayCounts()
+		dbOut.execute("test-" + inp.filesetId)


### PR DESCRIPTION
# Description
Added a new capability to associate the licensor and copyright information with the derived fileset, using the primary fileset's association with the licensor and copyright.

The new capability will be executed when content is loaded for each derived fileset.

# Task
[User Story 2368](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2368): uploader: associate derived filesets with licensor of primary fileset

# How to test
- Run the following command:

`time python3 load/UpdateDBPLicensorTables.py test s3://etl-development-input/ Spanish_N1SPAPBT_USX
`

### Outcome
- Check that each following file will have the sql statements to add the licensor and copyright info:

[Trans-test-SPAERVN_ET-json.sql.txt](https://github.com/user-attachments/files/17832829/Trans-test-SPAERVN_ET-json.sql.txt)
[Trans-test-SPAERVN_ET-usx.sql.txt](https://github.com/user-attachments/files/17832830/Trans-test-SPAERVN_ET-usx.sql.txt)
