### PR TITLE
Ticket-2368 Fix the UpdateDBPLicensorTables class to import the Input…

### DIFF
--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -13,12 +13,14 @@
 import re
 import sys
 import csv
+import os
 import math
 import subprocess
 from SqliteUtility import SqliteUtility
 from Config import Config
 from SQLUtility import SQLUtility
 from SQLBatchExec import SQLBatchExec
+from InputFileset import InputFileset
 from UpdateDBPTextFilesets import UpdateDBPTextFilesets
 from UpdateDBPBooksTable import UpdateDBPBooksTable
 from UpdateDBPBibleFilesSecondary import UpdateDBPBibleFilesSecondary
@@ -288,11 +290,12 @@ class UpdateDBPFilesetTables:
 ## Unit Test
 if (__name__ == '__main__'):
 	from LanguageReaderCreator import LanguageReaderCreator	
-	from InputFileset import *
-	from DBPLoadController import *
+	from InputProcessor import InputProcessor
+	from AWSSession import AWSSession
+	from DBPLoadController import DBPLoadController
 
 	config = Config.shared()
-	languageReader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
+	languageReader = LanguageReaderCreator("BLIMP").create("")
 	filesets = InputProcessor.commandLineProcessor(config, AWSSession.shared().s3Client, languageReader)
 	db = SQLUtility(config)
 	ctrl = DBPLoadController(config, db, languageReader)

--- a/load/UpdateDBPLicensorTables.py
+++ b/load/UpdateDBPLicensorTables.py
@@ -66,7 +66,7 @@ class UpdateDBPLicensorTables:
 				updates.append((copyrightDate, copyright, copyrightDescription, derivedHashId))
 
 		self.dbOut.insert(tableName, pkeyNames, attrNames, inserts)
-		self.dbOut.updateCol(tableName, pkeyNames, updates)
+		self.dbOut.update(tableName, pkeyNames, attrNames, updates)
 
 		return True
 


### PR DESCRIPTION
# Description
Fix the UpdateDBPLicensorTables class to import the InputFileset module and handle the exception error.

I recreated the issue: `NameError: name 'InputFileset' is not defined. Did you mean: 'inputFileset'?` when I executed only the `load/UpdateDBPFilesetTables.py` class, for example:

`python3 load/UpdateDBPFilesetTables.py test s3://etl-development-input JAAJARN1DA`

I noticed that the InputFileset module is being used but has not been imported. This issue should have been included with the commit: https://github.com/faithcomesbyhearing/dbp-etl/commit/005eec8962583ca3d398e3bc4d45e0d4a199bbd1#diff-14b2618c12b6106bb3e7779b837328f13ad055561ef006daa778bde62b5d14dfL19.

This class is used by load/DBPLoadController.py, and when I execute this module (load/DBPLoadController.py), the InputFileset class is loaded in the context. However, when I run UpdateDBPFilesetTables in isolation, it does not load. I suspect this is the issue occurring in the dev environment.

# How to test
- Run command:

python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input JAAJARN1DA