### PR TITLE
Task-2371 uploader (text): usx and json not being uploaded

### DIFF
--- a/load/S3Utility.py
+++ b/load/S3Utility.py
@@ -48,10 +48,10 @@ class S3Utility:
 						print("uploadAllFilesets. outFileset NOT added to database list: %s" % (outFileset.csvFilename))
 			elif inp.typeCode == "text":
 				subTypeCode = inp.subTypeCode()
-				if subTypeCode in {"text_plain", "text_usx", "text_json"}:
-					InputFileset.database.append(inp) ## Temp until text_format is ready
+				if subTypeCode in {"text_plain"}:
+					InputFileset.database.append(inp)
 				else:
-					done = self.uploadFileset(s3Bucket, inp)
+					self.uploadFileset(s3Bucket, inp)
 
 
 	def uploadFileset(self, s3Bucket, inputFileset):
@@ -76,13 +76,13 @@ class S3Utility:
 
 
 if (__name__ == '__main__'):
-	from SQLUtility import *
-	from InputProcessor import *
+	from SQLUtility import SQLUtility
+	from InputProcessor import InputProcessor
 	from UpdateDBPTextFilesets import UpdateDBPTextFilesets
 	from LanguageReaderCreator import LanguageReaderCreator	
 
 	config = Config.shared()
-	languageReader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
+	languageReader = LanguageReaderCreator("BLIMP").create("")
 	filesets = InputProcessor.commandLineProcessor(config, AWSSession.shared().s3Client, languageReader)
 
 	s3 = S3Utility(config)
@@ -125,5 +125,6 @@ if (__name__ == '__main__'):
 # time python3 load/S3Utility.py test-video /Volumes/FCBH/all-dbp-etl-test/ video/ENGESV/ENGESVP2DV
 # time python3 load/S3Utility.py test-video /Volumes/FCBH/all-dbp-etl-test/ video/ENGESX/ENGESVP2DV
 
+# time python3 load/S3Utility.py test s3://etl-development-input Spanish_N2SPNTLA_USX
 
 

--- a/load/UpdateDBPLicensorTables.py
+++ b/load/UpdateDBPLicensorTables.py
@@ -52,18 +52,13 @@ class UpdateDBPLicensorTables:
 
 		for (copyright, copyrightDate, copyrightDescription) in copyrights:
 			hashIdExisting = self.db.selectScalar("\
-				SELECT bible_fileset_copyrights.copyright,\
-					bible_fileset_copyrights.copyright_date,\
-					bible_fileset_copyrights.copyright_description,\
-					bible_fileset_copyrights.open_access\
+				SELECT bible_fileset_copyrights.copyright\
 				FROM bible_fileset_copyrights\
 				WHERE bible_fileset_copyrights.hash_id = %s", (derivedHashId,)
 			)
 
 			if hashIdExisting == None:
 				inserts.append((copyrightDate, copyright, copyrightDescription, derivedHashId))
-			else:
-				updates.append((copyrightDate, copyright, copyrightDescription, derivedHashId))
 
 		self.dbOut.insert(tableName, pkeyNames, attrNames, inserts)
 		self.dbOut.update(tableName, pkeyNames, attrNames, updates)


### PR DESCRIPTION
# Description
1. Removed incorrect logic that was preventing the upload of primary and derived filesets.

2. Additionally, I removed unnecessary logic that attempted to update the copyright information of an existing derived fileset using the same information.

# Task
[Bug 2371](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2371): uploader (text): usx and json not being uploaded

# How to test

You can run the following command and the outcome should be the following:
`````shell
python3 load/DBPLoadController.py test s3://dbp-etl-upload-dev-ya1mbvdty8tlq15r/ "2024-11-26-14-27-01/Semai_N2 & P2 SEAWYI_USX"
`````

### Outcome
[log_upload_filesets.txt](https://github.com/user-attachments/files/17922269/log_upload_filesets.txt)
