### PR TITLE
Ticket-2382 when creating derived filesets, link to the license group of the primary

### DIFF
--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -288,4 +288,6 @@ if (__name__ == '__main__'):
 # time python3 load/DBPLoadController.py test s3://etl-development-input/ Spanish_N1SPAPBT_USX
 
 
-
+# time python3 load/TestCleanup.py test ENGESVN2DA
+# time python3 load/TestCleanup.py test ENGESVN2DA-opus16
+# time python3 load/DBPLoadController.py test s3://etl-development-input/ ENGESVN2DA

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -128,10 +128,11 @@ class UpdateDBPFilesetTables:
 			filesetList = []
 			filesetList.append((inp.bibleId, inp.filesetId, setTypeCode, None, None, hashId))
 			lptsDBP.updateBibleFilesetTags(filesetList)
-			# If Opus-16 should be generated in ETL, we would need to invoke lptsDBP.updateBibleFilesetLicenseGroup(inp, hashId=hashId)
 
 			if inp.isDerivedFileset():
 				updateLicensor.processFileset(inp.lptsDamId, hashId)
+				# We need to create a license group for the derived audio fileset
+				lptsDBP.updateBibleFilesetLicenseGroup(inp, hashId=hashId)
 
 		elif inp.typeCode == "text":
 			hashId = lptsDBP.getHashId(bucket, inp.filesetId, inp.subTypeCode())


### PR DESCRIPTION
# Description
Add logic to include the license group when a derived fileset is being uploaded.

# Task
[Bug 2382](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2382): uploader: when creating derived filesets, link to the license group of the primary

# How to test it
I have tested it using the following command:
````shell
# time python3 load/TestCleanup.py test ENGESVN2DA-opus16
# time python3 load/DBPLoadController.py test s3://etl-development-input/ ENGESVN2DA
````

# Outcome
- You can see in the last line that the license_group_filesets record is created.
[Trans-ENGESVN2DA-opus16.sql.txt](https://github.com/user-attachments/files/18161689/Trans-ENGESVN2DA-opus16.sql.txt)

