### PR TITLE
Task-2021 uploader needs to recognize Covenant film content

### DIFF
--- a/load/BlimpLanguageReader.py
+++ b/load/BlimpLanguageReader.py
@@ -74,3 +74,7 @@ class BlimpLanguageReader (LanguageReaderInterface):
             return response
 
         return None
+
+    def getStocknumber(self, stocknumber):
+        (record) = self.service.getStocknumber(stocknumber)
+        return record

--- a/load/BlimpLanguageService.py
+++ b/load/BlimpLanguageService.py
@@ -72,6 +72,23 @@ class BlimpLanguageService:
 
         return (mediaId, modeType)
 
+    def getStocknumber(self, stocknumber):
+        sql = SQLUtility(self.config)
+
+        return sql.selectScalar("\
+            SELECT bft.description\
+            FROM bible_filesets bf\
+            INNER JOIN bible_fileset_connections bfc ON bfc.hash_id = bf.hash_id\
+            INNER JOIN bible_fileset_tags bft on bft.hash_id = bf.hash_id\
+            WHERE bft.name = 'stock_no'\
+            AND bft.description = %s\
+            GROUP BY bft.description\
+            LIMIT 1\
+            ",
+            (stocknumber)
+        )
+
+
 # BWF note: this is only called for text processing
 def getMediaByIdAndFormat(bibleId, format):
     config = Config()

--- a/load/Booknames.py
+++ b/load/Booknames.py
@@ -369,7 +369,19 @@ class Booknames:
 			'Zefanya':		'ZEP',
 			'Hagai':		'HAG',
 			'Zakharia':		'ZEC',
-			'Maleakhi':		'MAL'
+			'Maleakhi':		'MAL',
+			'Segment 01':	'C01',
+			'Segment 02':	'C02',
+			'Segment 03':	'C03',
+			'Segment 04':	'C04',
+			'Segment 05':	'C05',
+			'Segment 06':	'C06',
+			'Segment 07':	'C07',
+			'Segment 08':	'C08',
+			'Segment 09':	'C09',
+			'Segment 10':	'C10',
+			'Segment 11':	'C11',
+			'Segment 12':	'C12',
 		}
 		result = books.get(bookName, None)
 		return result

--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -291,3 +291,5 @@ if (__name__ == '__main__'):
 # time python3 load/TestCleanup.py test ENGESVN2DA
 # time python3 load/TestCleanup.py test ENGESVN2DA-opus16
 # time python3 load/DBPLoadController.py test s3://etl-development-input/ ENGESVN2DA
+
+# time python3 load/DBPLoadController.py test s3://etl-development-input/ "Covenant_Manobo, Obo SD_S2OBO_COV"

--- a/load/TextStockNumberProcessor.py
+++ b/load/TextStockNumberProcessor.py
@@ -219,7 +219,7 @@ class TextStockNumberProcessor:
 			if stocknumber != '':
 				stocknumberArrayFinal.append(stocknumber)
 
-		return stocknumberArrayFinal		
+		return stocknumberArrayFinal
 
 	def parseStockNumberFromDirectoryName(self, directoryName):
 		parts = directoryName.split("_")
@@ -228,8 +228,8 @@ class TextStockNumberProcessor:
 			if len(stockNumber) > 5:
 				stockNumber = stockNumber[:-3] + "/" + stockNumber[-3:]
 				return [stockNumber]
-			else:
-				self.errors.append("Could not parse stocknumber from directory name: [%s]" % (directoryName))
+			elif parts[0].lower() != "covenant":
+					self.errors.append("Could not parse stocknumber from directory name: [%s]" % (directoryName))
 		return None
 
 

--- a/load/UpdateDBPBooksTable.py
+++ b/load/UpdateDBPBooksTable.py
@@ -243,6 +243,18 @@ class UpdateDBPBooksTable:
 			if typeCode == "video":
 				seqMap = {"MAT": "B01", "MRK": "B02", "LUK": "B03", "JHN": "B04", "ACT": "B05"}
 				nameMap = {"MAT": "Matthew", "MRK": "Mark", "LUK": "Luke", "JHN": "John", "ACT": "Acts"}
+
+				# Extend Covenant Films with C01 to C12
+				# Extend seqMap with C01 to C12
+				for i in range(1, 13):
+					key = f"C{i:02}"  # Creates keys C01, C02, ... C12
+					seqMap[key] = key
+
+				# Extend nameMap with Segment 01 to Segment 12
+				for i in range(1, 13):
+					key = f"C{i:02}"  # Creates keys C01, C02, ... C12
+					nameMap[key] = f"Segment {i:02}"
+
 				for tocBook in tocBooks:
 					tocBook.bookSeq = seqMap.get(tocBook.bookId)
 					tocBook.name = nameMap.get(tocBook.bookId)
@@ -344,7 +356,10 @@ if (__name__ == '__main__'):
 	from DBPLoadController import *
 
 	config = Config.shared()
-	languageReader = LanguageReaderCreator("B").create(config.filename_lpts_xml)
+	migration_stage = "B" if os.getenv("DATA_MODEL_MIGRATION_STAGE") == None else os.getenv("DATA_MODEL_MIGRATION_STAGE")
+	lpts_xml = config.filename_lpts_xml if migration_stage == "B" else ""
+	languageReader = LanguageReaderCreator(migration_stage).create(lpts_xml)
+
 	filesets = InputProcessor.commandLineProcessor(config, AWSSession.shared().s3Client, languageReader)
 
 	db = SQLUtility(config)
@@ -366,4 +381,5 @@ if (__name__ == '__main__'):
 # time python3 load/UpdateDBPBooksTable.py test /Volumes/FCBH/all-dbp-etl-test/ HYWWAVN2ET
 # time python3 load/UpdateDBPBooksTable.py test-video /Volumes/FCBH/all-dbp-etl-test/ ENGESVP2DV
 
+# time python3 load/UpdateDBPBooksTable.py test s3://etl-development-input/ "Covenant_Manobo, Obo SD_S2OBO_COV"
 


### PR DESCRIPTION
# Description
Added logic to support loading content based on filesets related to the Covenant Film.

# Task
[User Story 2021](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2021): uploader needs to recognize Covenant film content

# How to test it
- You can run the following command to test
````shell
 time python3 load/DBPLoadController.py test s3://etl-development-input/ "Covenant_Manobo, Obo SD_S2OBO_COV"
````
You can see the sql outcome to create the entities: `bible_files` and `bible_books`: [Trans-OBOCOVS2DV.sql.txt](https://github.com/user-attachments/files/18236413/Trans-OBOCOVS2DV.sql.txt)

- You can run the following command to test UpdateDBPBooksTable:
````shell
time python3 load/UpdateDBPBooksTable.py test s3://etl-development-input/ "Covenant_Manobo, Obo SD_S2OBO_COV"
````

`````shell
# outcome
*** DBPLoadController:validate ***
Database 'dbp_2024_08_15' is opened.

Found 1 filesets to process
FilenameParser: video/OBOCOV/OBOCOVS2DV typeCode: video
FilenameReducer. Create file:  /home/vichugof/files/accepted/video_OBOCOV_OBOCOVS2DV.csv

DBPLoadController:validate. fileset: OBOCOVS2DV, csvFilename: /home/vichugof/files/accepted/video_OBOCOV_OBOCOVS2DV.csv 
DBPLoadController:validate. fileset: OBOCOVS2DV added to upload list
Num Errors  0
Database 'dbp_2024_08_15' is opened.
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C01', 'Segment 01', 'Segment 01', '1', 'OBOCOV', 'C01');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C02', 'Segment 02', 'Segment 02', '1', 'OBOCOV', 'C02');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C03', 'Segment 03', 'Segment 03', '1', 'OBOCOV', 'C03');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C04', 'Segment 04', 'Segment 04', '1', 'OBOCOV', 'C04');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C05', 'Segment 05', 'Segment 05', '1', 'OBOCOV', 'C05');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C06', 'Segment 06', 'Segment 06', '1', 'OBOCOV', 'C06');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C07', 'Segment 07', 'Segment 07', '1', 'OBOCOV', 'C07');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C08', 'Segment 08', 'Segment 08', '1', 'OBOCOV', 'C08');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C09', 'Segment 09', 'Segment 09', '1', 'OBOCOV', 'C09');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C10', 'Segment 10', 'Segment 10', '1', 'OBOCOV', 'C10');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C11', 'Segment 11', 'Segment 11', '1', 'OBOCOV', 'C11');
INSERT  INTO bible_books (book_seq, name, name_short, chapters, bible_id, book_id) VALUES ('C12', 'Segment 12', 'Segment 12', '1', 'OBOCOV', 'C12');
insert bible_books 12

real	0m3.132s
user	0m0.482s
sys	0m0.075s
`````

- You can run the following command to test FilenameParser

``````shell
time python3 load/FilenameParser.py test s3://etl-development-input/ "Covenant_Manobo, Obo SD_S2OBO_COV"
```````
`````shell
# outcome
PreValidate.validateFilesetId. regStockNumber: S2OBO/COV
PreValidate.validateFilesetId. damId: OBOCOVS2DV
PreValidate.validateFilesetId. index: 1, bibleId: OBOCOV
PreValidate.validateFilesetId. mediaSet and bibleIdSet not empty. return PreValidateResult..
PreValidate.validateDBPETL. result from validateFilesetId: <PreValidateResult.PreValidateResult object at 0x700f38f08a90>
PreValidate.validateDBPETL. result from validateFilesetId was not empty, so validateLPTS ???
Config:setConfigParametersFromProfile. profile: test, programRunning: FilenameParser.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: FilenameParser.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: FilenameParser.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: FilenameParser.py
Config 'test' is loaded.
Database 'dbp_2024_08_15' is opened.
InputProcessor.commandLineProcessor.. data: <PreValidateResult.PreValidateResult object at 0x700f38f08a90>
InputFileset construction. filesetId: OBOCOVS2DV location: s3://etl-development-input
Database 'dbp_2024_08_15' is opened.
Database 'dbp_2024_08_15' is opened.

Found 1 filesets to process
FilenameParser: video/OBOCOV/OBOCOVS2DV typeCode: video
FilenameReducer. Create file:  /home/vichugof/files/accepted/video_OBOCOV_OBOCOVS2DV.csv

Success Count: video5 -> 11

real	0m2.863s
user	0m0.435s
sys	0m0.073s
`````