### PR TITLE
Task-2627 uploader - incorrect table references and  Task-2628 uploader json files not parsed correctly

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -294,7 +294,11 @@ class FilenameRegex:
 				chapter = str(parser.maxChapterMap.get(match.group(2)))
 				file.setChapterEnd(chapter, parser.maxChapterMap)
 				file.setType(match.group(3))
-
+			elif self.name == "text4":
+				file.setBookSeq(match.group(1))
+				file.setBookId(match.group(2), parser.chapterMap)
+				file.setChapter(match.group(3), parser.maxChapterMap)
+				file.setType(match.group(4))
 			elif self.name == "audio99":
 				file.setDamid(match.group(1))
 				file.setBookSeq(match.group(2))
@@ -388,6 +392,9 @@ class FilenameParser:
 			## Example: 001GEN.usx
 			FilenameRegex("text3", r"([0-9]{3})?([A-Z0-9]{3}).(usx)"),
 
+			## {seq}{bookid}_{chap}.json
+			## Example: 041MRK_012.json
+			FilenameRegex("text4", r"([0-9]{3})?([A-Z0-9]{3})_([0-9]{3})?.(json)")
 		)
 		self.audioTemplates = (
 

--- a/load/SQLBatchExec.py
+++ b/load/SQLBatchExec.py
@@ -56,6 +56,24 @@ class SQLBatchExec:
 					self.statements.append("SET @%s = LAST_INSERT_ID();" % (keyValue,))
 			self.counts.append(("insert", tableName, len(values)))
 
+	def hasKeyStatement(self, keyValue):
+		"""
+		Check if the statements list contains a statement with the given keyValue.
+
+		Args:
+			keyValue (str): The key value to search for
+
+		Returns:
+			bool: True if found, False otherwise
+		"""
+		sanitized_key = SQLBatchExec.sanitize_value(keyValue)
+		search_pattern = f"SET @{sanitized_key} = LAST_INSERT_ID();"
+
+		for statement in self.statements:
+			if statement == search_pattern:
+				return True
+
+		return False
 
 	def insertSet(self, tableName, pkeyNames, attrNames, values):
 		if len(values) > 0:
@@ -93,6 +111,7 @@ class SQLBatchExec:
 			for value in values:
 				stmt = sql % value
 				stmt = stmt.replace("'None'", "NULL")
+				stmt = self.unquoteValues(stmt)
 				self.statements.append(stmt)
 			self.counts.append(("update", tableName, len(values)))
 

--- a/load/Validate.py
+++ b/load/Validate.py
@@ -36,7 +36,7 @@ class Validate:
 				ext = os.path.splitext(file.name)[-1]
 				if inp.typeCode == "audio" and ext not in {".mp3", ".opus", ".webm", ".m4a", ".jpg", ".tif", ".png", ".zip"}:
 					logger.invalidFileExt(file.name)
-				elif inp.typeCode == "text" and not ext in {".html", ".usx", ".xml", ".json"}:
+				elif inp.typeCode == "text" and not ext in {".usx"}:
 					logger.invalidFileExt(file.name)
 				elif inp.typeCode == "video" and ext != ".mp4":
 					logger.invalidFileExt(file.name)


### PR DESCRIPTION
# Description
Fixed the license_group_id references in the bible_filesets entity and Task-2628 reverted the change removing the regex used to parse the JSON file—since we still need to retrieve book and chapter information from it.

@bradflood According to Task-2628, I have reverted the regular expression used to parse JSON files because it is needed to extract book and chapter data from file. However, I removed the other text extensions in Validate.py, allowing us to load only USX file types for text filesets while still parsing the derived JSON files.

# Task
[Bug 2627](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2627): uploader - incorrect table references
[Bug 2628](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2628): uploader: json files not parsed correctly

# How test it
You can run the following command and you will see the similar outcome:
````shell
python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input Spanish_N2SPNTLA_USX
````
[Uploading Trans-test-SPNTLAO_ET-json_sql.txt…]()
