### PR TITLE
Task-2628 Bug 2628: uploader: json files not parsed correctly

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -254,7 +254,7 @@ class FilenameRegex:
 					file.setChapterEnd(file.chapter, parser.maxChapterMap)
 				else:
 					file.setType(match.group(5))
-			if self.name in ("video3", "video4"):
+			elif self.name in ("video3", "video4"):
 				file.addUnknown(match.group(1))
 				file.setBookName(match.group(2), parser.chapterMap)
 				file.setChapter(match.group(3), parser.maxChapterMap)
@@ -405,8 +405,8 @@ class FilenameParser:
 			FilenameRegex("audio100", r"^([A-Z0-9]{10})_([AB]\d{2})_([A-Z0-9]{3})_(\d{3})_(\d{3})-(\d{3})_(\d{3})\.(mp3|opus|webm)$"),
 
 			## {A/B}{ordering}___{chapter start}_{book name}__{mediaid}.mp3
-			## Example: B01___01_Matthew_____ENGGIDN2DA.mp3
-			FilenameRegex("audio101", r"^([AB]\d{2})_{3}(\d{2,3})_+([1-4]?[A-Za-z\-]+)_+([A-Z0-9]{10})\.(mp3|opus|webm)$"),
+			## Example: B01___01_Matthew_____ENGGIDN2DA.mp3 or B07___01_1CorinthiansENGESVN2DA.mp3
+			FilenameRegex("audio101", r"^([AB]\d{2})_{3}(\d{2,3})_+([1-4]?[A-Za-z\-]+)_*([A-Z0-9]{10})\.(mp3|opus|webm)$"),
 
 			## A01_{seq3}_title_title_title__damid.mp3
 			FilenameRegex("audioStory1", r"A01_+([0-9]{3})_([A-Za-z0-9_]+)_+([A-Z0-9]+).(mp3|opus|webm)"),


### PR DESCRIPTION
# Description
improve the regular expression to validate the audio files. The audio regex was not considering the case: B07___01_1CorinthiansENGESVN2DA.mp3

# Task
[Bug 2628](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2628): uploader: json files not parsed correctly

# How to test
Run the following command for audio content and you can see an outcome similar:
````shell
python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input ENGESVN2DA
````
- Outcome
[Trans-test-ENGESVN2DA_sql.txt](https://github.com/user-attachments/files/19457448/Trans-test-ENGESVN2DA_sql.txt)
