### PR TITLE
Ticket-2559 (R)tighten the regex patterns for uploader filenames

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -245,17 +245,6 @@ class FilenameRegex:
 		if match != None:
 			if self.name in ("video1", "video2"):
 				file.addUnknown(match.group(1))
-				file.setBookId(match.group(3), parser.chapterMap)
-				file.setChapter(match.group(4), parser.maxChapterMap)
-				if file.chapter.isdigit():
-					file.setType(match.group(7))
-					file.setVerseStart(match.group(5))
-					file.setVerseEnd(match.group(6))
-					file.setChapterEnd(file.chapter, parser.maxChapterMap)
-				else:
-					file.setType(match.group(5))
-			elif self.name in ("video3", "video4"):
-				file.addUnknown(match.group(1))
 				file.setBookId(match.group(2), parser.chapterMap)
 				file.setChapter(match.group(3), parser.maxChapterMap)
 				if file.chapter.isdigit():
@@ -369,21 +358,27 @@ class FilenameParser:
 		self.totalFiles = []
 
 		self.videoTemplates = (
-			## Language[-BibleVersion]_Book_Chapter-VerseStart-VerseEnd.mp4
-			## Example: English-KJV_JHN_1-1-18.mp4
-			FilenameRegex("video1", r"^([A-Za-z]+)-([A-Z0-9]{3})_([A-Z0-9]{3})_(\d{1,3})-(\d{1,2})b?-(\d{1,2})\.(mp4)$"),
+			# Language_Book_Chapter-VerseStart-VerseEnd.mp4
+			# Language[-BibleVersion]_Book_Chapter-VerseStart-VerseEnd.mp4
+			# Language[ BibleVersion]_Book_Chapter-VerseStart-VerseEnd.mp4
+			# Language[-BibleVersion]-[other text separated by "-"]_Book_Chapter-VerseStart-VerseEnd.mp4
+
+			## Example:
+			# English_JHN_1-1-18.mp4
+			# English-KJV_JHN_1-1-18.mp4
+			# English KJV_JHN_1-1-18.mp4
+			# English-KJV-other-version-info_JHN_1-1-18.mp4
+			# English-other-version-info_JHN_1-1-18.mp4
+			FilenameRegex("video1", r"^([A-Za-z\- ]+)_([A-Z0-9]{3})_(\d{1,3})-(\d{1,2})b?-(\d{1,2})\.(mp4)$"),
 
 			## Language[-BibleVersion]_Book_End_credits.mp4
-			## Example: English-KJV_JHN_End_credits.mp4
-			FilenameRegex("video2", r"^([A-Za-z]+)-([A-Z0-9]{3})_([A-Z0-9]{3})_(End_[Cc]redits)\.(mp4)$"),
-
-			## Language_Book_Chapter-VerseStart-VerseEnd.mp4 (NO Bible Version)
-			## Example: English_JHN_1-1-18.mp4
-			FilenameRegex("video3", r"^([A-Za-z]+)_([A-Z0-9]{3})_(\d{1,3})-(\d{1,2})b?-(\d{1,2})\.(mp4)$"),
-
-			## Language_Book_End_credits.mp4 (NO Bible Version)
-			## Example: English_JHN_End_credits.mp4
-			FilenameRegex("video4", r"^([A-Za-z]+)_([A-Z0-9]{3})_(End_[Cc]redits)\.(mp4)$"),
+			## Example:
+			# English-KJV_JHN_End_credits.mp4
+			# English KJV_JHN_End_credits.mp4
+			# English_JHN_End_credits.mp4
+			# English-KJV-other-version-info_JHN_End_credits.mp4
+			# English-other-version-info_JHN_End_credits.mp4
+			FilenameRegex("video2", r"^([A-Za-z\- ]+)_([A-Z0-9]{3})_(End_[Cc]redits)\.(mp4)$"),
 
 			## Example: COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4
 			FilenameRegex("video5", r'^(COVENANT)_SEGMENT\s*(\d{1,2})(.*)\.(mp4)$'),

--- a/load/TestFilenameParser.py
+++ b/load/TestFilenameParser.py
@@ -20,13 +20,23 @@ test_audio_files = [
 
 test_video_files = [
     "English_KJV_JHN_1-1-18.mp4",   # Full chapter - not match any
-    "English_KJV_JHN_End_credits.mp4",   # Full chapter - not match any
-    "Tajik_WBT_LUK_End_Credits.mp4",   # Full chapter - not match any
     "English-KJV_JHN_1-1-18.mp4",   # Full chapter - should match video1
-    "English-KJV_JHN_End_credits.mp4",   # Full chapter - should match video2
+    "English_KJV_JHN_1-1-18.mp4",   # Full chapter - not match any
+    "English_JHN_1-1-18.mp4",   # Full chapter - should match video1
+    "English-KJV-other-version-info_JHN_1-1-18.mp4",   # Full chapter - should match video1
+    "English-other-version-info_JHN_1-1-18.mp4",   # Full chapter - should match video1
+    "English other version info space_JHN_1-1-18.mp4",   # Full chapter - should match video1
+    "English KJV other version info space_JHN_1-1-18.mp4",   # Full chapter - should match video1
+    "Tajik_WBT_LUK_End_Credits.mp4",   # Full chapter - not match any
+    "English_KJV_JHN_End_credits.mp4",   # Full chapter - not match any
+    "English-KJV-other-version-info_JHN_End_credits.mp4",   # Full chapter - should match video2
+    "English-other-version-info_JHN_End_credits.mp4",   # Full chapter - should match video2
+    "English-other_version-info_JHN_End_credits.mp4",   # Full chapter - not match any
+    "English other version space_JHN_End_credits.mp4",   # Full chapter - should match video2
+    "English KVJ other version space_JHN_End_credits.mp4",   # Full chapter - should match video2
     "Tajik-WBT_LUK_End_Credits.mp4",   # Full chapter - should match video2
-    "English_JHN_1-1-18.mp4",   # Full chapter - should match video3
-    "English_JHN_End_Credits.mp4",   # Full chapter - should match video3
+    "English-KJV_JHN_End_credits.mp4",   # Full chapter - should match video2
+    "English_JHN_End_Credits.mp4",   # Full chapter - should match video1
     "COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4",   # Full chapter - should match video5
     "COVENANT_SEGMENT 02 – The Fall.mp4",   # Full chapter - should match video5
     "COVENANT - Fall.mp4",  # Invalid case - should not match any
@@ -39,6 +49,22 @@ test_text_files = [
     "041MRK.usx",   # Full chapter - should match text3
     "001GEN_001-010.usx",  # Invalid case - should not match any
     "INVALID_FILENAME.usx"  # Invalid case - should not match any
+]
+
+test_cases_parser = [
+    # Valid cases
+    ("001GEN.usx", "GEN", "1", "1", "", "usx"),
+    ("ENGESVN2DA_B01_MAT_001.mp3", "MAT", "001", "1", "", "mp3"),
+    ("IRUNLCP1DA_B13_1TH_001_001-001_010.opus", "1TH", "001", "001", "010", "opus"),
+    ("English-other-version-info_JHN_End_credits.mp4", "JHN", "end", "", "", "mp4"),
+    ("English-other version info space_JHN_1-1-18.mp4", "JHN", "1", "1", "18", "mp4"),
+    ("English-KJV_JHN_1-1-18.mp4", "JHN", "1", "1", "18", "mp4"),
+    ("English-KJV_JHN_End_credits.mp4", "JHN", "end", "", "", "mp4"),
+    ("COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4", "C01", "1", "1", "1", "mp4"),
+    # Invalid cases
+    ("001GEN_001-010.usx", "", "", "", "", ""),
+    ("INVALID_FILENAME.mp3", "", "", "", "", ""),
+    ("ENGES_B01_MAT_00.mp3", "", "", "", "", ""),
 ]
 
 def validate_files(files, templates, file_type):
@@ -67,12 +93,61 @@ def validate_files(files, templates, file_type):
 
     return success_count, failure_count
 
+def test_parse_method(parser, test_cases):
+    success_count = 0
+    failure_count = 0
+
+    print("\n=====================================")
+    print("Testing parse method of FilenameParser")
+    print("=====================================")
+
+    for filename, expected_bookId, expected_chapter, expected_verseStart, expected_verseEnd, expected_type in test_cases:
+        # Wrap the filename in a tuple as expected by the parser
+        filename_tuple = (filename, len(filename), None)
+
+        # Parse the filename
+        # file = parser.parseOneFilename3(parser.audioTemplates + parser.videoTemplates + parser.textTemplates, "", [filename_tuple])
+        file = parser.parseOneFilename3(parser.audioTemplates + parser.videoTemplates + parser.textTemplates, "", filename_tuple)
+
+        # Validate the results
+        if file.bookId == expected_bookId and \
+           file.chapter == expected_chapter and \
+           file.verseStart == expected_verseStart and \
+           file.verseEnd == expected_verseEnd and \
+           file.type == expected_type:
+            success_count += 1
+            print(f"✅ Passed: {filename}")
+        else:
+            print(f"❌ Failed: {filename}")
+            print(f"   - Expected: bookId={expected_bookId}, chapter={expected_chapter}, verseStart={expected_verseStart}, verseEnd={expected_verseEnd}, type={expected_type}")
+            print(f"   - Got: bookId={file.bookId}, chapter={file.chapter}, verseStart={file.verseStart}, verseEnd={file.verseEnd}, type={file.type}")
+            failure_count += 1
+
+    return success_count, failure_count
+
 if __name__ == '__main__':
     from FilenameParser import FilenameParser
     from Config import Config
     config = Config()
     parser = FilenameParser(config)
-
+    parser.chapterMap = {
+        "GEN": 50,
+        "MAT": 28,
+        "MRK": 16,
+        "JHN": 21,
+        "C01": 2,
+    }
+    parser.maxChapterMap = {
+        "GEN": 50,
+        "MAT": 28,
+        "MRK": 16,
+        "JHN": 21,
+        "C01": 2,
+    }
+    parser.covenantBookNameMap = {
+        "C01": "Intro & Garden of Eden",
+        "C02": "Noah, Abram, Ishmael is Born",
+    }
     audio_success, audio_failure = validate_files(test_audio_files, parser.audioTemplates, "audio")
     video_success, video_failure = validate_files(test_video_files, parser.videoTemplates, "video")
     text_success, text_failure = validate_files(test_text_files, parser.textTemplates, "text")
@@ -80,11 +155,14 @@ if __name__ == '__main__':
     total_success = audio_success + video_success + text_success
     total_failure = audio_failure + video_failure + text_failure
 
+    parse_success, parse_failure = test_parse_method(parser, test_cases_parser)
+    total_success += parse_success
+    total_failure += parse_failure
     print("\nSummary:")
 
     # Validation check
-    expected_success_count = 19
-    expected_failure_count = 12
+    expected_success_count = 38
+    expected_failure_count = 14
 
     if total_success == expected_success_count and total_failure == expected_failure_count:
         print("✅ Test executed successfully.")


### PR DESCRIPTION
# Description
The regex for validating and parsing the video files has been updated.

# Task
[User Story 2559](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2559): (R)tighten the regex patterns for uploader filenames

# How test it.

You can run the unit test `load/TestFilenameParser.py` and you will view the following outcome for video:

````shell
=====================================
File Type :  video
=====================================
❌ Invalid: English_KJV_JHN_1-1-18.mp4 (No pattern matched)
✅ Valid: English-KJV_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English-KJV
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
❌ Invalid: English_KJV_JHN_1-1-18.mp4 (No pattern matched)
✅ Valid: English_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English-KJV-other-version-info_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English-KJV-other-version-info
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English-other-version-info_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English-other-version-info
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English other version info space_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English other version info space
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English KJV other version info space_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English KJV other version info space
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
❌ Invalid: Tajik_WBT_LUK_End_Credits.mp4 (No pattern matched)
❌ Invalid: English_KJV_JHN_End_credits.mp4 (No pattern matched)
✅ Valid: English-KJV-other-version-info_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English-KJV-other-version-info
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: English-other-version-info_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English-other-version-info
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
❌ Invalid: English-other_version-info_JHN_End_credits.mp4 (No pattern matched)
✅ Valid: English other version space_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English other version space
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: English KVJ other version space_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English KVJ other version space
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: Tajik-WBT_LUK_End_Credits.mp4 (Matched: video2)
   - Group 1: Tajik-WBT
   - Group 2: LUK
   - Group 3: End_Credits
   - Group 4: mp4
✅ Valid: English-KJV_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English-KJV
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: English_JHN_End_Credits.mp4 (Matched: video2)
   - Group 1: English
   - Group 2: JHN
   - Group 3: End_Credits
   - Group 4: mp4
✅ Valid: COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4 (Matched: video5)
   - Group 1: COVENANT
   - Group 2: 01
   - Group 3:  – Intro and Garden of Eden
   - Group 4: mp4
✅ Valid: COVENANT_SEGMENT 02 – The Fall.mp4 (Matched: video5)
   - Group 1: COVENANT
   - Group 2: 02
   - Group 3:  – The Fall
   - Group 4: mp4
❌ Invalid: COVENANT - Fall.mp4 (No pattern matched)
❌ Invalid: INVALID_FILENAME.mp4 (No pattern matched)
````
- Also, I have created a new test method to validate the parse function. You can see the results of this test in the following outcome:

```shell
# INPUT
test_cases_parser = [
    # Valid cases
    ("001GEN.usx", "GEN", "1", "1", "", "usx"),
    ("ENGESVN2DA_B01_MAT_001.mp3", "MAT", "001", "1", "", "mp3"),
    ("IRUNLCP1DA_B13_1TH_001_001-001_010.opus", "1TH", "001", "001", "010", "opus"),
    ("English-other-version-info_JHN_End_credits.mp4", "JHN", "end", "", "", "mp4"),
    ("English-other version info space_JHN_1-1-18.mp4", "JHN", "1", "1", "18", "mp4"),
    ("English-KJV_JHN_1-1-18.mp4", "JHN", "1", "1", "18", "mp4"),
    ("English-KJV_JHN_End_credits.mp4", "JHN", "end", "", "", "mp4"),
    ("COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4", "C01", "1", "1", "1", "mp4"),
    # Invalid cases
    ("001GEN_001-010.usx", "", "", "", "", ""),
    ("INVALID_FILENAME.mp3", "", "", "", "", ""),
    ("ENGES_B01_MAT_00.mp3", "", "", "", "", ""),
]
```