### PR TITLE
Task-2629 uploader - loading video causes bible_books localized names to be overwritten with English

### DIFF
--- a/load/SQLUtility.py
+++ b/load/SQLUtility.py
@@ -140,7 +140,11 @@ class SQLUtility:
 			results[row[0]] = row[1]
 		return results
 
-
+	# Get a map of the first column to the second column
+	# The first column is the key, and the second is the value
+	# the value can be a list or a set
+	# Example: selectMapList("SELECT name, age FROM users", ())
+	# returns {'John': [25, 34, 12], 'Jane': [30, 46]}
 	def selectMapList(self, statement, values):
 		resultSet = self.select(statement, values)
 		results = {}
@@ -150,7 +154,6 @@ class SQLUtility:
 			results[row[0]] = values
 		return results
 
-
 	def selectMapSet(self, statement, values):
 		resultSet = self.select(statement, values)
 		results = {}
@@ -158,7 +161,18 @@ class SQLUtility:
 			values = results.get(row[0], set())
 			values.add(row[1])
 			results[row[0]] = values
-		return results		
+		return results
+
+	# Get a map of the first column to the rest of the columns
+	# The first column is the key, and the rest are the values
+	# Example: selectMapRow("SELECT id, name, age FROM users", ())
+	# returns {1: ('John', 25), 2: ('Jane', 30)}
+	def selectMapRow(self, statement, values):
+		resultSet = self.select(statement, values)
+		results = {}
+		for row in resultSet:
+			results[row[0]] = row[1:]
+		return results
 
 
 	def error(self, cursor, stmt, error):

--- a/load/TestFilenameParser.py
+++ b/load/TestFilenameParser.py
@@ -3,7 +3,6 @@
 # Sample filenames for testing
 test_audio_files = [
     "ENGESVN2DA_B01_MAT_001.mp3",   # Full chapter - should match audio99
-    "ENGESVN2DA_B01_MAT_001.mp3",   # Full chapter - should match audio99
     "IRUNLCP1DA_B13_1TH_001_001-001_010.opus",  # Partial chapter - should match audio100
     "SPANESV1DA_A23_GEN_005.webm",  # Full chapter - should match audio99
     "FRENCHL1DA_A32_ZEC_010_003-011_009.mp3",  # Partial chapter - should match audio100
@@ -106,7 +105,6 @@ def test_parse_method(parser, test_cases):
         filename_tuple = (filename, len(filename), None)
 
         # Parse the filename
-        # file = parser.parseOneFilename3(parser.audioTemplates + parser.videoTemplates + parser.textTemplates, "", [filename_tuple])
         file = parser.parseOneFilename3(parser.audioTemplates + parser.videoTemplates + parser.textTemplates, "", filename_tuple)
 
         # Validate the results
@@ -161,7 +159,7 @@ if __name__ == '__main__':
     print("\nSummary:")
 
     # Validation check
-    expected_success_count = 38
+    expected_success_count = 37
     expected_failure_count = 14
 
     if total_success == expected_success_count and total_failure == expected_failure_count:


### PR DESCRIPTION
# Description
Add a feature to prevent overwriting Bible book names when a localized book name is available for the video loading process.

# Task
[Bug 2629](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2629): uploader - loading video causes bible_books localized names to be overwritten with English

# How to test it
I have used the following two examples and I saw that won't try to overwrite the bible book names:

````shell
# Command Covenant_Aceh SD_S2ACE_COV
-> python3 load/UpdateDBPBooksTable.py test s3://etl-development-input/ "Covenant_Aceh SD_S2ACE_COV"

# outcome
*** DBPLoadController:validate ***
Database 'dbp_2025_03_06' is opened.

Found 1 filesets to process
FilenameParser: video/ACECOV/ACECOVS2DV typeCode: video
FilenameReducer. Create file:  /home/vichugof/files/accepted/video_ACECOV_ACECOVS2DV.csv

DBPLoadController:validate. fileset: ACECOVS2DV, csvFilename: /home/vichugof/files/accepted/video_ACECOV_ACECOVS2DV.csv 
DBPLoadController:validate. fileset: ACECOVS2DV added to upload list
Num Errors  0
Database 'dbp_2025_03_06' is opened.
Database 'dbp_2025_03_06' is opened.
NO INSERT, UPDATE, or DELETE Transactions to process

# Command SPNBDAP2DV
->  python3 load/UpdateDBPBooksTable.py test s3://etl-development-input/ "SPNBDAP2DV"

# Outcome
*** DBPLoadController:validate ***
Database 'dbp_2025_03_06' is opened.

Found 1 filesets to process
FilenameParser: video/SPABDA/SPNBDAP2DV typeCode: video
FilenameReducer. Create file:  /home/vichugof/files/accepted/video_SPABDA_SPNBDAP2DV.csv

DBPLoadController:validate. fileset: SPNBDAP2DV, csvFilename: /home/vichugof/files/accepted/video_SPABDA_SPNBDAP2DV.csv 
DBPLoadController:validate. fileset: SPNBDAP2DV added to upload list
openErrorReport /home/vichugof/files/errors/Errors.out
WARN SPNBDAP2DV chapters missing JHN 1-9, JHN 11-21, LUK 1-9, LUK 11-24, MAT 1-9, MAT 11-28, MRK 1-9, MRK 11-16
Num Errors  1
Database 'dbp_2025_03_06' is opened.
Database 'dbp_2025_03_06' is opened.
NO INSERT, UPDATE, or DELETE Transactions to process

````