### PR TITLE
Task-2629 uploader - loading video causes bible_books localized names to be overwritten with English

### DIFF
--- a/load/UpdateDBPBooksTable.py
+++ b/load/UpdateDBPBooksTable.py
@@ -292,7 +292,7 @@ class UpdateDBPBooksTable:
 					toc.name = mapping.get("name", "")
 					toc.nameShort = mapping.get("nameShort", "")
 
-		db.close()
+				db.close()
 		return tocBooks
 
 


### PR DESCRIPTION
# Description
Fixed the logic to close the database connection.

# Task
https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2629

# How to test it
- Load audio and video filesets:

````shell
time python3 load/UpdateDBPBooksTable.py test s3://etl-development-input/ "SPNBDAP2DV"
time python3 load/UpdateDBPBooksTable.py test s3://etl-development-input/ "ENGESVN2DA"
````
