### PR TITLE
Task-2614 (R)uploader: create and publish zip for Gospel Films

### DIFF
--- a/load/UpdateDBPBibleFilesSecondary.py
+++ b/load/UpdateDBPBibleFilesSecondary.py
@@ -54,30 +54,72 @@ class UpdateDBPBibleFilesSecondary:
 				Log.getLogger(inp.filesetId).message(Log.EROR, "Failure in zip file creation %s" % (err,))
 		# Handle video filesets related to the Gospel Films and the process to generate the zip file
 		if inp.typeCode == "video" and inp.isMP4Fileset() and len(inp.filesetId) == 10:
-			gospelBookNameMap = self.db.selectMap("SELECT id, notes FROM books where book_group = 'Gospels'", None)
-			AWSSession.shared() # ensure AWSSession init
-			session = boto3.Session(profile_name = self.config.s3_aws_profile)
+			gospelBookNameMap = self.db.selectMap(
+				"SELECT id, notes FROM books WHERE book_group = 'Gospels'", None
+			)
+
+			# Ensure AWS Session initialization
+			AWSSession.shared()
+			session = boto3.Session(profile_name=self.config.s3_aws_profile)
 			s3Client = session.client('s3')
-			Log.getLogger(inp.filesetId).message(Log.INFO, "Creating Zip for %s and creating temp credentials" % (inp.filesetId,))
-			print("Creating Zip for %s and creating temp credentials key: %s" % (inp.filesetId, self.config.s3_zipper_user_key))
-			zipperService = S3ZipperService(s3zipper_user_key=self.config.s3_zipper_user_key, s3zipper_user_secret=self.config.s3_zipper_user_secret, s3_client=s3Client, region=self.config.s3_aws_region)
 
-			for bookId in gospelBookNameMap.keys():
-				listFiles = inp.videoFileNamesByBook(bookId)
-				if len(listFiles) > 0:
-					Log.getLogger(inp.filesetId).message(Log.INFO, "Creating Zip for %s and # of mp4: %s bucket %s" % (bookId, len(listFiles), self.config.s3_vid_bucket))
+			logger = Log.getLogger(inp.filesetId)
+			logger.message(Log.INFO, f"Creating Zip for {inp.filesetId} and creating temp credentials")
+			print(f"Creating Zip for {inp.filesetId} and creating temp credentials key: {self.config.s3_zipper_user_key}")
 
-					listCompleteFiles = [ "%s/%s/%s" % (self.config.s3_vid_bucket, inp.filesetPrefix, f) for f in listFiles ]
+			zipperService = S3ZipperService(
+				s3zipper_user_key=self.config.s3_zipper_user_key,
+				s3zipper_user_secret=self.config.s3_zipper_user_secret,
+				s3_client=s3Client,
+				region=self.config.s3_aws_region
+			)
+
+			for bookId in gospelBookNameMap:
+				files = inp.videoFileNamesByBook(bookId)
+				if files:
+					logger.message(
+						Log.INFO,
+						f"Creating Zip for {bookId} with {len(files)} mp4 files in bucket {self.config.s3_vid_bucket}"
+					)
+
+					# Construct full S3 keys for each file, updating .mp4 filenames to include '_web'
+					# We can assume that the transcoder has already created the _web.mp4 files
+					# and they are in the same bucket as the original files.
+					# Example: "s3://bucket/prefix/file.mp4" becomes "s3://bucket/prefix/file_web.mp4"
+					completeFiles = [
+						f"{self.config.s3_vid_bucket}/{inp.filesetPrefix}/{f[:-4] + '_web.mp4' if f.endswith('.mp4') else f}"
+						for f in files
+					]
+
+					# Validate that each S3 key exists in the video bucket.
+					# If the key does not exist, log a warning. However, the zip file creation should
+					# not fail if a file is missing and it should still proceed to create the zip file
+					# with the available files.
+					for s3Key in completeFiles:
+						# Remove the bucket portion from the key (expected format: "bucket/prefix/file")
+						parts = s3Key.split('/', 1)
+						key = parts[1] if len(parts) > 1 else s3Key
+						try:
+							s3Client.head_object(Bucket=self.config.s3_vid_bucket, Key=key)
+						except s3Client.exceptions.ClientError as e:
+							errorCode = e.response['Error']['Code']
+							if errorCode in ['404', 'NoSuchKey']:
+								print(f"\nWARN: Creating Zip Video File - Missing s3 key: {key}")
+							else:
+								logger.message(Log.EROR, f"Error checking S3 key: {key} - {errorCode}")
+								raise
+
 					try:
-						zipFilename = "%s/%s_%s.zip" % (inp.filesetPrefix, inp.filesetId, bookId)
-						result = zipperService.zip_files(self.config.s3_vid_bucket, listCompleteFiles, zipFilename)
+						zipFilename = f"{inp.filesetPrefix}/{inp.filesetId}_{bookId}.zip"
+						result = zipperService.zip_files(self.config.s3_vid_bucket, completeFiles, zipFilename)
 						if result.get("State") != "SUCCESS":
-							Log.getLogger(inp.filesetId).message(Log.EROR, "Failure creating Zip: %s" % (result,))
+							logger.message(Log.EROR, f"Failure creating Zip: {result}")
 						else:
 							inp.addInputFile(zipFilename, 0)
-							Log.getLogger(inp.filesetId).message(Log.INFO, "Zip created: %s" % (zipFilename,))
+							print(f"Zip created: {zipFilename}\n")
 					except Exception as e:
-						Log.getLogger(inp.filesetId).message(Log.EROR, "Error creating Zip: %s" % (e,))
+						logger.message(Log.EROR, f"Error creating Zip: {e}")
+
 
 	def getZipInternalDir(self, damId, languageRecord):
 		langName = languageRecord.LangName()


### PR DESCRIPTION
# Description
Added logic to create the ZIP for the video fileset using `_web.mp4` (720p) content instead of 1080p content.

# Task
[User Story 2614](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2614): (R)uploader: create and publish zip for Gospel Films

# How to test it
I have used the fileset: SPNBDAP2DV from bucket: etl-development-input and I could view the following outcome.

`````shell
*** DBPLoadController:upload ***
DBPLoadController:uploadAllFilesets.. inp.typeCode: video subTypeCode: None inp.id: SPNBDAP2DV
upload: aws --profile dbp-dev s3 sync --acl bucket-owner-full-control "s3://etl-development-input/SPNBDAP2DV" "s3://etl-development-input/video/SPABDA/SPNBDAP2DV"
********* BEGIN SUBMIT TRANSCODE *********  5.7 sec
********* BEGIN CHECK TRANSCODE *********  0.0 sec
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_JHN_10-1-21.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_JHN_End_Credits.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_LUK_10-1-24.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_LUK_End_Credits.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_MAT_10-1-23.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_MAT_End_Credits.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_MRK_10-1-16.mp4
Job Complete video/SPABDA/SPNBDAP2DV/Spanish-BDA_MRK_End_Credits.mp4
Transcode video/SPABDA/SPNBDAP2DV succeeded.
********* TRANSCODE DONE *********  10.1 sec
Creating Zip for SPNBDAP2DV and creating temp credentials key: gdnxi5KdSu8cqqMSvd6zb4

WARN: Creating Zip Video File - Missing s3 key: video/SPABDA/SPNBDAP2DV/Spanish-BDA_JHN_End_Credits_web.mp4
Starting zip process with payload: bucket: etl-development-input file_paths: ['etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_JHN_10-1-21_web.mp4', 'etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_JHN_End_Credits_web.mp4'] zip_output_prefix: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_JHN.zip fileMapper: etl-development-input/video/SPABDA/SPNBDAP2DV/fileMapper_20250404T061251.json
s3Zipper State: STARTED progress time: 0.0 minutes
Zip created: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_JHN.zip

Starting zip process with payload: bucket: etl-development-input file_paths: ['etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_LUK_10-1-24_web.mp4', 'etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_LUK_End_Credits_web.mp4'] zip_output_prefix: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_LUK.zip fileMapper: etl-development-input/video/SPABDA/SPNBDAP2DV/fileMapper_20250404T061302.json
s3Zipper State: STARTED progress time: 3.973642985026042e-09 minutes
Zip created: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_LUK.zip

Starting zip process with payload: bucket: etl-development-input file_paths: ['etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_MAT_10-1-23_web.mp4', 'etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_MAT_End_Credits_web.mp4'] zip_output_prefix: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_MAT.zip fileMapper: etl-development-input/video/SPABDA/SPNBDAP2DV/fileMapper_20250404T061324.json
s3Zipper State: STARTED progress time: 5.5631001790364584e-08 minutes
Zip created: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_MAT.zip

Starting zip process with payload: bucket: etl-development-input file_paths: ['etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_MRK_10-1-16_web.mp4', 'etl-development-input/video/SPABDA/SPNBDAP2DV/Spanish-BDA_MRK_End_Credits_web.mp4'] zip_output_prefix: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_MRK.zip fileMapper: etl-development-input/video/SPABDA/SPNBDAP2DV/fileMapper_20250404T061344.json
s3Zipper State: STARTED progress time: 0.0 minutes
Zip created: video/SPABDA/SPNBDAP2DV/SPNBDAP2DV_MRK.zip

Num Errors 0
`````
- And if you check the content of zip, you can see the _web.mp4 content. (Note: we only have a _web.mp4 file in this dev bucket).
```shell
unzip -l SPNBDAP2DV_JHN.zip
Archive:  SPNBDAP2DV_JHN.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 49039679  2025-04-04 01:12   /Spanish-BDA_JHN_10-1-21_web.mp4
---------                     -------
 49039679                     1 file
````