### PR TITLE
Task-2631 uploader: update CPC after successful audio load

### DIFF
--- a/load/BlimpLanguageRecord.py
+++ b/load/BlimpLanguageRecord.py
@@ -194,7 +194,7 @@ class BlimpLanguageRecord (LanguageRecordInterface):
                 return stockNumber
         return None
 
-    def CalculateProductCode(self, filesetId: str, typeCode: str, bookId: str) -> Optional[str]:
+    def CalculateProductCode(self, filesetId: str, typeCode: str, bookId: Optional[str]) -> Optional[str]:
         """
         Determines the product code based on a stock number and (optionally) the book ID.
 
@@ -209,7 +209,7 @@ class BlimpLanguageRecord (LanguageRecordInterface):
             return None  # no valid stock number
 
         # If type_code is 'video' (case-insensitive) and we have a bookId, append "_bookId"
-        if typeCode.lower() == "video" and bookId:
+        if typeCode.lower() == "video" and bookId is not None:
             return f"{stocknumber}_{bookId}"
 
         # Otherwise, just return the stock number alone

--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -154,39 +154,55 @@ class DBPLoadController:
 		(languageRecord, _) = self.languageReader.getLanguageRecordLoose(inputFileset.typeCode, inputFileset.bibleId, inputFileset.filesetId)
 		stocknumber = languageRecord.StockNumberByFilesetId(inputFileset.filesetId)
 
-		zipFiles = inputFileset.zipFilesIndexedByBookId()
+		# possible statuses are: {0: Video, 1: Audio}
+		mode = 0 if inputFileset.typeCode == "video" else 1
+
+		licensor = languageRecord.LicensorList()[0] if languageRecord.LicensorList() != None else ""
+		if len(licensor) >= 3:
+			(_, licensorName, _) = licensor
+		else:
+			licensorName = ""
+
 		productCodes = {}
-		gospelBookNameMap = self.db.selectMap("SELECT id, notes FROM books where book_group = 'Gospels'", None)
-		for bookId in gospelBookNameMap.keys():
-			zipFile = zipFiles.get(bookId)
-			if zipFile != None:
-				# Check if the zip file has a valid path E.g. video/{BibleId}/{FilesetId}/{Zipfile}.zip
-				if zipFile.hasValidFilesetPath(inputFileset.typeCode, inputFileset.bibleId, inputFileset.filesetId) is False:
-					Log.getLogger(inputFileset.filesetId).message(Log.EROR, "BiblebrainLink does not have a correct path: %s" % zipFile.name)
-					continue
 
-				licensor = languageRecord.LicensorList()[0] if languageRecord.LicensorList() != None else ""
-				if len(licensor) >= 3:
-					(_, licensorName, _) = licensor
-				else:
-					licensorName = ""
+		if inputFileset.typeCode == "video":
+			zipFiles = inputFileset.zipFilesIndexedByBookId()
+			gospelBookNameMap = self.db.selectMap("SELECT id, notes FROM books where book_group = 'Gospels'", None)
+			for bookId in gospelBookNameMap.keys():
+				zipFile = zipFiles.get(bookId)
+				if zipFile != None:
+					# Check if the zip file has a valid path E.g. video/{BibleId}/{FilesetId}/{Zipfile}.zip
+					if zipFile.hasValidFilesetPath(inputFileset.typeCode, inputFileset.bibleId, inputFileset.filesetId) is False:
+						Log.getLogger(inputFileset.filesetId).message(Log.EROR, "BiblebrainLink does not have a correct path: %s" % zipFile.name)
+						continue
 
-				# possible statuses are: {0: Video, 1: Audio}
-				mode = 0 if inputFileset.typeCode == "video" else 1
-
-				# The zipFile.name is the path to the zip file with the pattern video/{BibleId}/{FilesetId}/{Zipfile}.zip
-				biblebrainLink = self.config.cdn_partner_base + "/" + zipFile.name
-				productCode = languageRecord.CalculateProductCode(inputFileset.filesetId, inputFileset.typeCode, bookId)
-				productCodes[productCode] = {
-					ProductCodeColumns.StockNumber: stocknumber,
-					ProductCodeColumns.Language: languageRecord.LangName().strip() if languageRecord.LangName() != None else "",
-					ProductCodeColumns.BiblebrainLink: biblebrainLink,
-					ProductCodeColumns.Licensor: licensorName,
-					ProductCodeColumns.CoLicensor: languageRecord.CoLicensor().strip() if languageRecord.CoLicensor() != None else "",
-					ProductCodeColumns.Mode: mode,
-					ProductCodeColumns.Version: languageRecord.Version(),
-					ProductCodeColumns.LanguageCountry: languageRecord.Country(),
-				}
+					# The zipFile.name is the path to the zip file with the pattern video/{BibleId}/{FilesetId}/{Zipfile}.zip
+					biblebrainLink = self.config.cdn_partner_base + "/" + zipFile.name
+					productCode = languageRecord.CalculateProductCode(inputFileset.filesetId, inputFileset.typeCode, bookId)
+					productCodes[productCode] = {
+						ProductCodeColumns.StockNumber: stocknumber,
+						ProductCodeColumns.Language: languageRecord.LangName().strip() if languageRecord.LangName() != None else "",
+						ProductCodeColumns.BiblebrainLink: biblebrainLink,
+						ProductCodeColumns.Licensor: licensorName,
+						ProductCodeColumns.CoLicensor: languageRecord.CoLicensor().strip() if languageRecord.CoLicensor() != None else "",
+						ProductCodeColumns.Mode: mode,
+						ProductCodeColumns.Version: languageRecord.Version(),
+						ProductCodeColumns.LanguageCountry: languageRecord.Country(),
+					}
+		elif inputFileset.typeCode == "audio" and inputFileset.isDerivedFileset() is False:
+			zipFile = inputFileset.zipFile()
+			biblebrainLink = self.config.cdn_partner_base + "/" + zipFile.name
+			productCode = languageRecord.CalculateProductCode(inputFileset.filesetId, inputFileset.typeCode, None)
+			productCodes[productCode] = {
+				ProductCodeColumns.StockNumber: stocknumber,
+				ProductCodeColumns.Language: languageRecord.LangName().strip() if languageRecord.LangName() != None else "",
+				ProductCodeColumns.BiblebrainLink: biblebrainLink,
+				ProductCodeColumns.Licensor: licensorName,
+				ProductCodeColumns.CoLicensor: languageRecord.CoLicensor().strip() if languageRecord.CoLicensor() != None else "",
+				ProductCodeColumns.Mode: mode,
+				ProductCodeColumns.Version: languageRecord.Version(),
+				ProductCodeColumns.LanguageCountry: languageRecord.Country(),
+			}
 
 		if productCodes != {}:
 			mondayService.synchronize(productCodes)


### PR DESCRIPTION
# Description
Added logic to synchronize the Monday Product Code Board when an audio fileset is loaded.

# Task
[User Story 2631](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2631): uploader: update CPC after successful audio load

# How to test it

- You can try to load content for the fileset: ENGESVN2DA
`````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "ENGESVN2DA"
`````
- Then, you should view the product code: N2ESV in the Monday CPC board.