### PR TITLE
Task-2658 uploader for video does not set verse_sequence for end credits

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -156,6 +156,9 @@ class Filename:
 				self.errors.append("non-number verse start: %s" % (verseStart))
 		self.verseStartNum = int(self.verseStart)
 
+	## This is used to set the verse start number from the verse start string
+	def setVerseStartNum(self, verseStartNum):
+		self.verseStartNum = verseStartNum
 
 	def setVerseEnd(self, verseEnd):
 		self.verseEnd = verseEnd

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -188,7 +188,16 @@ class UpdateDBPFilesetTables:
 			for row in reader:
 				bookId = row["book_id"]
 				if row["chapter_start"] == "end":
-					(chapterStart, verseStart, verseEnd) = self.convertChapterStart(bookId)
+					# It will return error if the bookId is not in the list of books that are supported such as MAT, MRK, LUK, JHN
+					(chapterStart, _, _) = self.convertChapterStart(bookId)
+					verseStart = row["verse_start"] if row["verse_start"] != "" else "0"
+					try:
+						verseSequence = int(row["verse_sequence"]) if row["verse_sequence"] != "" else 0
+					except ValueError:
+						verseSequence = 0
+					# The verseStart will be modified for books that are not supported by the method convertChapterStart.
+					if verseSequence != 0:
+						verseStart = str(verseSequence)
 				else:
 					chapterStart = int(row["chapter_start"]) if row["chapter_start"] != "" else None
 					verseStart = row["verse_start"] if row["verse_start"] != "" else 1
@@ -236,7 +245,11 @@ class UpdateDBPFilesetTables:
 		self.dbOut.update(tableName, pkeyNames, attrNames, updateRows)
 		self.dbOut.delete(tableName, pkeyNames, deleteRows)
 
-
+	# We have a fixed values for chapterStart, verseStart, verseEnd for the following books
+	# MAT 28:21,21
+	# MRK 16:21,21
+	# LUK 24:54,54
+	# JHN 21:26,26
 	def convertChapterStart(self, bookId):
 		if bookId == "MAT":
 			return (28, "21", "21")
@@ -294,3 +307,4 @@ if (__name__ == '__main__'):
 # time python3 load/UpdateDBPFilesetTables.py
 
 # python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input Spanish_N2SPNTLA_USX
+# python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input SPNBDAP2DV


### PR DESCRIPTION
# Description
Included logic to set a sequence for the end credit file in video filesets. Additionally, added logic to calculate the maximum chapter and verse for each book according to the files, which will later be used to set the verse start number (verse_sequence) for files that are “end” files of a book.

# Task
[Bug 2658](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2658): uploader for video does not set verse_sequence for end credits

# How to test it
I have used the following fileset: URIWBTN2DV
`````shell
python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input URIWBTN2DV
`````
- Outcome
[Trans-test-URIWBTN2DV_sql.txt](https://github.com/user-attachments/files/19697085/Trans-test-URIWBTN2DV_sql.txt)

