### PR TITLE
Task‑2624 and 2658: Video Uploader should create metadata for mp4 files and uploader for video does not set verse_sequence for end credits

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -60,6 +60,13 @@ class InputFile:
 
 		return directoryParts[0] == typeCode and directoryParts[1] == bibleId and directoryParts[2] == filesetId
 
+	def extension(self):
+		parts = self.name.split(".")
+		if len(parts) > 1:
+			return parts[-1]
+		else:
+			return None
+
 class InputFileset:
 
 	BUCKET = "BUCKET"


### PR DESCRIPTION
# Description
Added logic to include all content related to video filesets, and fixed the logic (Task-2658) so that, for end‑of‑book video content, verse_end = verse_start and chapter_end = chapter_start

# Task
[User Story 2624](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2624): Video Uploader should create metadata for mp4 files
[Bug 2658](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2658): (R)uploader for video does not set verse_sequence for end credits

# How to test
I have used tow filesets, video and audio: SPNBDAP2DV and ENGESVN2DA

- You can check that for the SPNBDAP2DV fileset all content will be created: _web.mp4, mp4 and m3u8
````shell
time python3 load/UpdateDBPFilesetTables.py test s3://etl-development-input SPNBDAP2DV
````
- Outcome
[Trans-test-SPNBDAP2DV_sql.txt](https://github.com/user-attachments/files/19809389/Trans-test-SPNBDAP2DV_sql.txt)


- You can check that for the ENGESVN2DA fileset all mp3 content will be created
````shell
time python3  load/UpdateDBPFilesetTables.py test s3://etl-development-input ENGESVN2DA
````
- Outcome
[Trans-test-ENGESVN2DA_sql.txt](https://github.com/user-attachments/files/19809395/Trans-test-ENGESVN2DA_sql.txt)
