### PR TITLE
Task-2692: uploader filesize incorrect and uploader issues with zip file in bible_files_secondary

### DIFF
--- a/load/InputFileset.py
+++ b/load/InputFileset.py
@@ -67,6 +67,14 @@ class InputFile:
 		else:
 			return None
 
+	def only_file_name(self) -> str:
+		"""
+		Return just the filename portion of self.name, stripping any trailing slashes.
+		"""
+		# Remove any trailing slash or backslash
+		cleaned = self.name.rstrip("/\\")
+		return os.path.basename(cleaned)
+
 class InputFileset:
 
 	BUCKET = "BUCKET"


### PR DESCRIPTION
# Description
- Task-2692 – Fixed the logic for calculating the file size of Bible files attached to a video fileset. We now use the S3 client to obtain the file-size values for both .m3u8 and _web.mp4 files.
- Task-2697 – Improved the logic for creating records in bible_files_secondary for both audio and video filesets. The comparison constraint no longer includes the full path and video filesets are now covered by the insertion logic.
 
# Task
[Bug 2692](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2692): uploader filesize incorrect
[Bug 2697](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2697): uploader issues with zip file in bible_files_secondary

# How to test
I have used the following two filesets:
``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ ENGESVN2DA
# outcome
INSERT  INTO bible_files_secondary (file_type, hash_id, file_name) VALUES ('zip', '049d0c45b02f', 'ENGESVN2DA.zip');
``````

``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "SPNBDAP2DV"

# Outcome
SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
START TRANSACTION;
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('10', '21', 'Spanish-BDA_JHN_10-1-21_stream.m3u8', '499', NULL, '1', 'b18563a987c4', 'JHN', '10', '1');
SET @Spanish_BDA_JHN_10_1_21_stream_m3u8 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('10', '21', 'Spanish-BDA_JHN_10-1-21_web.mp4', '143', NULL, '1', 'b18563a987c4', 'JHN', '10', '1');
SET @Spanish_BDA_JHN_10_1_21_web_mp4 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('10', '21', 'Spanish-BDA_JHN_10-1-21.mp4', '886603', NULL, '1', 'b18563a987c4', 'JHN', '10', '1');
UPDATE bible_files SET file_size = '143' WHERE hash_id='b18563a987c4' AND book_id='MAT' AND chapter_start='10' AND verse_start='1'; -- prior=499
UPDATE bible_files SET file_size = '844869' WHERE hash_id='b18563a987c4' AND book_id='MAT' AND chapter_start='10' AND verse_start='1'; -- prior=499
INSERT  INTO bible_files_secondary (file_type, hash_id, file_name) VALUES ('zip', 'b18563a987c4', 'SPNBDAP2DV_JHN.zip');
INSERT  INTO bible_files_secondary (file_type, hash_id, file_name) VALUES ('zip', 'b18563a987c4', 'SPNBDAP2DV_LUK.zip');
INSERT  INTO bible_files_secondary (file_type, hash_id, file_name) VALUES ('zip', 'b18563a987c4', 'SPNBDAP2DV_MAT.zip');
INSERT  INTO bible_files_secondary (file_type, hash_id, file_name) VALUES ('zip', 'b18563a987c4', 'SPNBDAP2DV_MRK.zip');
ROLLBACK;
EXIT
``````