### PR TITLE
Task-2467 Added support for loading Acts Films content. This includes…

### DIFF
--- a/load/BlimpLanguageReader.py
+++ b/load/BlimpLanguageReader.py
@@ -78,3 +78,6 @@ class BlimpLanguageReader (LanguageReaderInterface):
     def getStocknumber(self, stocknumber):
         (record) = self.service.getStocknumber(stocknumber)
         return record
+    # Get the list of books for the Gospels and Apostolic History group
+    def getGospelsAndApostolicHistoryBooks(self):
+       return self.service.getGospelsAndApostolicHistoryMap()

--- a/load/BlimpLanguageService.py
+++ b/load/BlimpLanguageService.py
@@ -89,6 +89,24 @@ class BlimpLanguageService:
         )
 
 
+    def getGospelsAndApostolicHistoryMap(self):
+        sql = SQLUtility(self.config)
+        result = sql.selectMap("SELECT id, notes FROM books WHERE book_group IN ('Gospels', 'Apostolic History')", None)
+
+        # Validate and sanitize the result
+        validated_result = {}
+        for book_id, notes in result.items():
+            if not book_id or not isinstance(book_id, str):
+                continue
+            if not notes or not isinstance(notes, str):
+                notes = "No notes available"  # Default value for missing or invalid notes
+            validated_result[book_id] = notes.strip()
+
+        if not validated_result:
+            raise ValueError("No valid data found for Gospels and Apostolic History mapping.")
+
+        return validated_result
+
 # BWF note: this is only called for text processing
 def getMediaByIdAndFormat(bibleId, format):
     config = Config()

--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -80,7 +80,7 @@ class DBPLoadController:
 		print("\n*** DBPLoadController:upload ***")
 		self.s3Utility.uploadAllFilesets(inputFilesets)
 		dbOut = SQLBatchExec(self.config)
-		secondary = UpdateDBPBibleFilesSecondary(self.config, self.db, dbOut)
+		secondary = UpdateDBPBibleFilesSecondary(self.config, self.db, dbOut, self.languageReader)
 		secondary.createAllZipFiles(inputFilesets)
 		Log.writeLog(self.config)
 
@@ -167,8 +167,9 @@ class DBPLoadController:
 		# Synchronize Monday product codes for video filesets
 		if inputFileset.typeCode == "video":
 			zipFiles = inputFileset.zipFilesIndexedByBookId()
-			gospelBookNameMap = self.db.selectMap("SELECT id, notes FROM books where book_group = 'Gospels'", None)
-			for bookId in gospelBookNameMap.keys():
+			# We need to get the list of books that are allowed for the video fileset (Gospels and Apostolic History)
+			booksAllowed = self.languageReader.getGospelsAndApostolicHistoryBooks()
+			for bookId in booksAllowed:
 				zipFile = zipFiles.get(bookId)
 				if zipFile != None:
 					# Check if the zip file has a valid path E.g. video/{BibleId}/{FilesetId}/{Zipfile}.zip
@@ -377,3 +378,4 @@ if (__name__ == '__main__'):
 # time python3 load/DBPLoadController.py test s3://etl-development-input/ "Covenant_Aceh SD_S2ACE_COV"
 
 # time python3 load/DBPLoadController.py test s3://etl-development-input/ "SPNBDAP2DV"
+# time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"

--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -252,8 +252,10 @@ class FilenameRegex:
 				file.setChapter(match.group(3), parser.maxChapterMap)
 				if file.chapter.isdigit():
 					file.setType(match.group(6))
-					file.setVerseStart(match.group(4))
-					file.setVerseEnd(match.group(5))
+					if len(match.groups()) >= 4 and match.group(4) is not None:
+						file.setVerseStart(match.group(4))
+					if len(match.groups()) >= 5 and match.group(5) is not None:
+						file.setVerseEnd(match.group(5))
 					file.setChapterEnd(file.chapter, parser.maxChapterMap)
 				else:
 					file.setType(match.group(4))
@@ -372,7 +374,8 @@ class FilenameParser:
 			# English KJV_JHN_1-1-18.mp4
 			# English-KJV-other-version-info_JHN_1-1-18.mp4
 			# English-other-version-info_JHN_1-1-18.mp4
-			FilenameRegex("video1", r"^([A-Za-z\- ]+)_([A-Z0-9]{3})_(\d{1,3})-(\d{1,2})b?-(\d{1,2})\.(mp4)$"),
+			# Fang-BSG_ACT_1.mp4
+			FilenameRegex("video1", r"^([A-Za-z\- ]+)_([A-Z0-9]{3})_(\d{1,3})(?:-(\d{1,2})b?-(\d{1,2}))?\.(mp4)$"),
 
 			## Language[-BibleVersion]_Book_End_credits.mp4
 			## Example:

--- a/load/PreValidate.py
+++ b/load/PreValidate.py
@@ -105,6 +105,7 @@ class PreValidate:
 
 	## Validate filesetId and return PreValidateResult
 	def validateFilesetId(self, directoryName):
+		# directoryName is the name of the directory, which is the filesetId
 		filesetId = directoryName
 		filesetId1 = directoryName.split("-")[0]
 		print("PreValidate.validateFilesetId. directoryName: %s, filesetId: %s, filesetId1: %s " % (directoryName, filesetId, filesetId1))
@@ -118,6 +119,7 @@ class PreValidate:
 
 			if results == None:
 				parts = directoryName.split("_")
+				# It supports the case when the directory name is example: "Covenant_Manobo, Obo SD_S2OBO_COV"
 				if len(parts) > 2 and parts[0] == "Covenant":
 					# check if the directory name is a covenant stock number
 					covenantStocknumber = directoryName[-9:]

--- a/load/TestFilenameParser.py
+++ b/load/TestFilenameParser.py
@@ -36,6 +36,8 @@ test_video_files = [
     "Tajik-WBT_LUK_End_Credits.mp4",   # Full chapter - should match video2
     "English-KJV_JHN_End_credits.mp4",   # Full chapter - should match video2
     "English_JHN_End_Credits.mp4",   # Full chapter - should match video1
+    "Fang-BSG_ACT_1.mp4",  # Full chapter - should match video1
+    "Fang-BSG_ACT_End_credits.mp4", # Full chapter - should match video2
     "COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4",   # Full chapter - should match video5
     "COVENANT_SEGMENT 02 – The Fall.mp4",   # Full chapter - should match video5
     "COVENANT - Fall.mp4",  # Invalid case - should not match any
@@ -60,6 +62,8 @@ test_cases_parser = [
     ("English-KJV_JHN_1-1-18.mp4", "JHN", "1", "1", "18", "mp4"),
     ("English-KJV_JHN_End_credits.mp4", "JHN", "end", "", "", "mp4"),
     ("COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4", "C01", "1", "1", "1", "mp4"),
+    ("Fang-BSG_ACT_1.mp4", "ACT", "1", "1", "", "mp4"),
+    ("Fang-BSG_ACT_End_credits.mp4", "ACT", "end", "", "", "mp4"),
     # Invalid cases
     ("001GEN_001-010.usx", "", "", "", "", ""),
     ("INVALID_FILENAME.mp3", "", "", "", "", ""),
@@ -134,6 +138,7 @@ if __name__ == '__main__':
         "MRK": 16,
         "JHN": 21,
         "C01": 2,
+        "ACT": 28,
     }
     parser.maxChapterMap = {
         "GEN": 50,
@@ -141,6 +146,7 @@ if __name__ == '__main__':
         "MRK": 16,
         "JHN": 21,
         "C01": 2,
+        "ACT": 28,
     }
     parser.covenantBookNameMap = {
         "C01": "Intro & Garden of Eden",
@@ -159,7 +165,7 @@ if __name__ == '__main__':
     print("\nSummary:")
 
     # Validation check
-    expected_success_count = 37
+    expected_success_count = 41
     expected_failure_count = 14
 
     if total_success == expected_success_count and total_failure == expected_failure_count:

--- a/load/TextStockNumberProcessor.py
+++ b/load/TextStockNumberProcessor.py
@@ -228,7 +228,7 @@ class TextStockNumberProcessor:
 			if len(stockNumber) > 5:
 				stockNumber = stockNumber[:-3] + "/" + stockNumber[-3:]
 				return [stockNumber]
-			elif parts[0].lower() != "covenant":
+			elif parts[0].strip().lower() not in {"covenant"}:
 					self.errors.append("Could not parse stocknumber from directory name: [%s]" % (directoryName))
 		return None
 

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -83,7 +83,7 @@ class UpdateDBPFilesetTables:
 
 		dbConn = SQLUtility(self.config)
 		bookIdSet = self.getBibleBooks(inp.typeCode, inp.csvFilename, inp.databasePath)
-		updateBibleFilesSecondary = UpdateDBPBibleFilesSecondary(self.config, dbConn, self.dbOut)
+		updateBibleFilesSecondary = UpdateDBPBibleFilesSecondary(self.config, dbConn, self.dbOut, self.languageReader)
 		updateLicensor = UpdateDBPLicensorTables(dbConn, self.dbOut)
 		bucket = self.config.s3_vid_bucket if inp.typeCode == "video" else self.config.s3_bucket
 		# it needs to know if the new inputFileset has new files to set the flag content_loaded
@@ -340,7 +340,7 @@ class UpdateDBPFilesetTables:
 
 					exists, variant_file_size = s3.get_key_info(self.config.s3_vid_bucket, f"{prefix}/{filename}")
 					if not exists:
-						print(f"WARN: missing S3 key: {key}")
+						print(f"WARN: missing S3 key: {s3_key}")
 						continue
 
 					# We need to get the file size for web_mp4 and m3u8 from s3 because the csv file will have the size of the mp4 file
@@ -419,6 +419,7 @@ class UpdateDBPFilesetTables:
 	# MRK 16:21,21
 	# LUK 24:54,54
 	# JHN 21:26,26
+	# ACT 28:32,32
 	def convertChapterStart(self, bookId):
 		if bookId == "MAT":
 			return (28, "21", "21")
@@ -428,6 +429,8 @@ class UpdateDBPFilesetTables:
 			return (24, "54", "54")
 		elif bookId == "JHN":
 			return (21, "26", "26")
+		elif bookId == "ACT":
+			return (28, "32", "32")
 		else:
 			print("ERROR: Unexpected book %s in UpdateDBPDatabase." % (bookId))
 			sys.exit()

--- a/load/UpdateDBPLPTSTable.py
+++ b/load/UpdateDBPLPTSTable.py
@@ -249,10 +249,10 @@ class UpdateDBPLPTSTable:
 
 		elif inputFileset.typeCode == "video":
 			PRODUCT_CODE_VIDEO_TEMPLATE = "product_code:%s"
+			# We need to get the list of books that are allowed for the video fileset (Gospels and Apostolic History)
+			booksAllowed = self.languageReader.getGospelsAndApostolicHistoryBooks()
 
-			gospelBookNameMap = self.db.selectMap("SELECT id, notes FROM books where book_group = 'Gospels'", None)
-
-			for bookId in gospelBookNameMap.keys():
+			for bookId in booksAllowed:
 				listFiles = inputFileset.videoFileNamesByBook(bookId)
 				if len(listFiles) > 0:
 					oldProductCode = tagNameMap.get(PRODUCT_CODE_VIDEO_TEMPLATE % bookId, None)


### PR DESCRIPTION
# Description
Added support for loading Acts Films content. This includes a new regex to validate the video files and logic to load files only when the folder name matches with fileset ID format

# Changelog
- Update the entity `bible_files_secondary`
- Update the entity `bible_fileset_tags` with the value name=`product_code:ACT` and description=`N2FAN/BSG_ACT`
- Create the zip using s3zipper
- Synchronize the product code data with Monday
- Created the folder: `s3://etl-development-input/FANBSGP2DV` to do testing

# Task
[User Story 2467](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2467): Enable loading of Acts films

# How to test
I have used the following folder to test:
``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"

# Outcome
SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
START TRANSACTION;
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('1', NULL, 'Fang-BSG_ACT_1_stream.m3u8', '463', NULL, '1', '8b4001ee1809', 'ACT', '1', '1');
SET @Fang_BSG_ACT_1_stream_m3u8 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('1', NULL, 'Fang-BSG_ACT_1_web.mp4', '311', NULL, '1', '8b4001ee1809', 'ACT', '1', '1');
SET @Fang_BSG_ACT_1_web_mp4 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('1', NULL, 'Fang-BSG_ACT_1.mp4', '515477331', NULL, '1', '8b4001ee1809', 'ACT', '1', '1');
SET @Fang_BSG_ACT_1_mp4 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('28', '1', 'Fang-BSG_ACT_End_credits_stream.m3u8', '503', NULL, '1', '8b4001ee1809', 'ACT', '28', '1');
SET @Fang_BSG_ACT_End_credits_stream_m3u8 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('28', '1', 'Fang-BSG_ACT_End_credits_web.mp4', '341', NULL, '1', '8b4001ee1809', 'ACT', '28', '1');
SET @Fang_BSG_ACT_End_credits_web_mp4 = LAST_INSERT_ID();
INSERT  INTO bible_files (chapter_end, verse_end, file_name, file_size, duration, verse_sequence, hash_id, book_id, chapter_start, verse_start) VALUES ('28', '1', 'Fang-BSG_ACT_End_credits.mp4', '99672462', NULL, '1', '8b4001ee1809', 'ACT', '28', '1');
SET @Fang_BSG_ACT_End_credits_mp4 = LAST_INSERT_ID();
INSERT  INTO bible_files_secondary (file_type, hash_id, file_name) VALUES ('zip', '8b4001ee1809', 'FANBSGP2DV_ACT.zip');
INSERT  INTO bible_fileset_tags (description, admin_only, notes, iso, hash_id, name, language_id) VALUES ('N2FAN/BSG_ACT', '1', NULL, 'eng', '8b4001ee1809', 'product_code:ACT', '6414');
COMMIT;
EXIT

``````
- You should run the following unit test and should pass
```````shell
-> python3 load/TestFilenameParser.py test

# Outcome
Config:setConfigParametersFromProfile. profile: test, programRunning: TestFilenameParser.py
Config 'test' is loaded.

=====================================
File Type :  audio
=====================================
✅ Valid: ENGESVN2DA_B01_MAT_001.mp3 (Matched: audio99)
   - Group 1: ENGESVN2DA
   - Group 2: B01
   - Group 3: MAT
   - Group 4: 001
   - Group 5: mp3
✅ Valid: IRUNLCP1DA_B13_1TH_001_001-001_010.opus (Matched: audio100)
   - Group 1: IRUNLCP1DA
   - Group 2: B13
   - Group 3: 1TH
   - Group 4: 001
   - Group 5: 001
   - Group 6: 001
   - Group 7: 010
   - Group 8: opus
✅ Valid: SPANESV1DA_A23_GEN_005.webm (Matched: audio99)
   - Group 1: SPANESV1DA
   - Group 2: A23
   - Group 3: GEN
   - Group 4: 005
   - Group 5: webm
✅ Valid: FRENCHL1DA_A32_ZEC_010_003-011_009.mp3 (Matched: audio100)
   - Group 1: FRENCHL1DA
   - Group 2: A32
   - Group 3: ZEC
   - Group 4: 010
   - Group 5: 003
   - Group 6: 011
   - Group 7: 009
   - Group 8: mp3
✅ Valid: B01___01_Matthew_____ENGGIDN2DA.mp3 (Matched: audio101)
   - Group 1: B01
   - Group 2: 01
   - Group 3: Matthew
   - Group 4: ENGGIDN2DA
   - Group 5: mp3
✅ Valid: A02___12_Exodus_____SPANESV1DA.opus (Matched: audio101)
   - Group 1: A02
   - Group 2: 12
   - Group 3: Exodus
   - Group 4: SPANESV1DA
   - Group 5: opus
✅ Valid: B11___123_Psalms___FRENCHL1DA.webm (Matched: audio101)
   - Group 1: B11
   - Group 2: 123
   - Group 3: Psalms
   - Group 4: FRENCHL1DA
   - Group 5: webm
✅ Valid: B27___08_Revelation__ASMDPIN1DA.mp3 (Matched: audio101)
   - Group 1: B27
   - Group 2: 08
   - Group 3: Revelation
   - Group 4: ASMDPIN1DA
   - Group 5: mp3
❌ Invalid: B27____08_Revelation__ASMDPIN1DA.mp3 (No pattern matched)
❌ Invalid: ENGES_B01_MAT_001.mp3 (No pattern matched)
❌ Invalid: ENGES_B0_MAT_001.mp3 (No pattern matched)
❌ Invalid: ENGES_B01_MAT_00.mp3 (No pattern matched)
❌ Invalid: INVALID_FILENAME.mp3 (No pattern matched)

=====================================
File Type :  video
=====================================
❌ Invalid: English_KJV_JHN_1-1-18.mp4 (No pattern matched)
✅ Valid: English-KJV_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English-KJV
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
❌ Invalid: English_KJV_JHN_1-1-18.mp4 (No pattern matched)
✅ Valid: English_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English-KJV-other-version-info_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English-KJV-other-version-info
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English-other-version-info_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English-other-version-info
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English other version info space_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English other version info space
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
✅ Valid: English KJV other version info space_JHN_1-1-18.mp4 (Matched: video1)
   - Group 1: English KJV other version info space
   - Group 2: JHN
   - Group 3: 1
   - Group 4: 1
   - Group 5: 18
   - Group 6: mp4
❌ Invalid: Tajik_WBT_LUK_End_Credits.mp4 (No pattern matched)
❌ Invalid: English_KJV_JHN_End_credits.mp4 (No pattern matched)
✅ Valid: English-KJV-other-version-info_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English-KJV-other-version-info
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: English-other-version-info_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English-other-version-info
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
❌ Invalid: English-other_version-info_JHN_End_credits.mp4 (No pattern matched)
✅ Valid: English other version space_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English other version space
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: English KVJ other version space_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English KVJ other version space
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: Tajik-WBT_LUK_End_Credits.mp4 (Matched: video2)
   - Group 1: Tajik-WBT
   - Group 2: LUK
   - Group 3: End_Credits
   - Group 4: mp4
✅ Valid: English-KJV_JHN_End_credits.mp4 (Matched: video2)
   - Group 1: English-KJV
   - Group 2: JHN
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: English_JHN_End_Credits.mp4 (Matched: video2)
   - Group 1: English
   - Group 2: JHN
   - Group 3: End_Credits
   - Group 4: mp4
✅ Valid: Fang-BSG_ACT_1.mp4 (Matched: video1)
   - Group 1: Fang-BSG
   - Group 2: ACT
   - Group 3: 1
   - Group 4: None
   - Group 5: None
   - Group 6: mp4
✅ Valid: Fang-BSG_ACT_End_credits.mp4 (Matched: video2)
   - Group 1: Fang-BSG
   - Group 2: ACT
   - Group 3: End_credits
   - Group 4: mp4
✅ Valid: COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4 (Matched: video5)
   - Group 1: COVENANT
   - Group 2: 01
   - Group 3:  – Intro and Garden of Eden
   - Group 4: mp4
✅ Valid: COVENANT_SEGMENT 02 – The Fall.mp4 (Matched: video5)
   - Group 1: COVENANT
   - Group 2: 02
   - Group 3:  – The Fall
   - Group 4: mp4
❌ Invalid: COVENANT - Fall.mp4 (No pattern matched)
❌ Invalid: INVALID_FILENAME.mp4 (No pattern matched)

=====================================
File Type :  text
=====================================
✅ Valid: 001GEN.usx (Matched: text3)
   - Group 1: 001
   - Group 2: GEN
   - Group 3: usx
✅ Valid: 040MAT.usx (Matched: text3)
   - Group 1: 040
   - Group 2: MAT
   - Group 3: usx
✅ Valid: 041MRK.usx (Matched: text3)
   - Group 1: 041
   - Group 2: MRK
   - Group 3: usx
❌ Invalid: 001GEN_001-010.usx (No pattern matched)
❌ Invalid: INVALID_FILENAME.usx (No pattern matched)

=====================================
Testing parse method of FilenameParser
=====================================
✅ Passed: 001GEN.usx
✅ Passed: ENGESVN2DA_B01_MAT_001.mp3
✅ Passed: IRUNLCP1DA_B13_1TH_001_001-001_010.opus
✅ Passed: English-other-version-info_JHN_End_credits.mp4
✅ Passed: English-other version info space_JHN_1-1-18.mp4
✅ Passed: English-KJV_JHN_1-1-18.mp4
✅ Passed: English-KJV_JHN_End_credits.mp4
✅ Passed: COVENANT_SEGMENT 01 – Intro and Garden of Eden.mp4
✅ Passed: Fang-BSG_ACT_1.mp4
✅ Passed: Fang-BSG_ACT_End_credits.mp4
✅ Passed: 001GEN_001-010.usx
✅ Passed: INVALID_FILENAME.mp3
✅ Passed: ENGES_B01_MAT_00.mp3

Summary:
✅ Test executed successfully.

````````