### PR TITLE
Task-2714 Updated the unique constraint on bible_files to include file_name.

### DIFF
--- a/load/SQLBatchExec.py
+++ b/load/SQLBatchExec.py
@@ -45,8 +45,7 @@ class SQLBatchExec:
 			names = attrNames + pkeyNames
 			valsubs = ["'%s'"] * len(names)
 			# temporary -- remove the error checks. This should only be used in exceptional circumstances
-			# sql = "INSERT INTO %s (%s) VALUES (%s);" % (tableName, ", ".join(names), ", ".join(valsubs))
-			sql = "INSERT  INTO %s (%s) VALUES (%s);" % (tableName, ", ".join(names), ", ".join(valsubs))
+			sql = "INSERT INTO %s (%s) VALUES (%s);" % (tableName, ", ".join(names), ", ".join(valsubs))
 			for value in values:
 				stmt = sql % value
 				stmt = self.unquoteValues(stmt)

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -198,10 +198,10 @@ class UpdateDBPFilesetTables:
 
 		# 3) Apply in batches
 		table = "bible_files"
-		pkeys = ("hash_id", "book_id", "chapter_start", "verse_start")
-		attrs = ("chapter_end", "verse_end", "file_name", "file_size", "duration", "verse_sequence")
+		pkeys = ("hash_id", "book_id", "chapter_start", "verse_start", "file_name")
+		attrs = ("chapter_end", "verse_end", "file_size", "duration", "verse_sequence")
 
-		self.dbOut.insert(table, pkeys, attrs, inserts, keyPosition=2)
+		self.dbOut.insert(table, pkeys, attrs, inserts, keyPosition=9)
 		self.dbOut.updateCol(table, pkeys, updates)
 		self.dbOut.delete(table, pkeys, deletes)
 
@@ -229,23 +229,23 @@ class UpdateDBPFilesetTables:
 				key = (row["book_id"], chapterStart, verseStart)
 				dbpValue = dbpMap.get(key)
 				if dbpValue == None:
-					insertRows.append((chapterEnd, verseEnd, row["file_name"], fileSize, duration, verseSequence,
-						hashId, row["book_id"], chapterStart, verseStart))
+					insertRows.append((chapterEnd, verseEnd, fileSize, duration, verseSequence,
+						hashId, row["book_id"], chapterStart, verseStart, row["file_name"]))
 				else:
 					del dbpMap[key]
 					(dbpChapterEnd, dbpVerseEnd, dbpFileName, dbpFileSize, dbpDuration) = dbpValue
 
 					# primary keys: "hash_id", "book_id", "chapter_start", "verse_start"
 					if chapterEnd != dbpChapterEnd:
-						updateRows.append(("chapter_end", chapterEnd, dbpChapterEnd, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("chapter_end", chapterEnd, dbpChapterEnd, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if verseEnd != dbpVerseEnd:
-						updateRows.append(("verse_end", verseEnd, dbpVerseEnd, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("verse_end", verseEnd, dbpVerseEnd, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if row["file_name"] != dbpFileName:
-						updateRows.append(("file_name", row["file_name"], dbpFileName, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("file_name", row["file_name"], dbpFileName, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if fileSize != dbpFileSize:
-						updateRows.append(("file_size", fileSize, dbpFileSize, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("file_size", fileSize, dbpFileSize, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if duration != dbpDuration:
-						updateRows.append(("duration", duration, dbpDuration, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("duration", duration, dbpDuration, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 
 		return (insertRows, updateRows, [])
 
@@ -276,22 +276,22 @@ class UpdateDBPFilesetTables:
 				key = (row["book_id"], chapterStart, verseStart)
 				dbpValue = dbpMap.get(key)
 				if dbpValue == None:
-					insertRows.append((chapterEnd, verseEnd, fileName, fileSize, duration, verseSequence,
-						hashId, row["book_id"], chapterStart, verseStart))
+					insertRows.append((chapterEnd, verseEnd, fileSize, duration, verseSequence,
+						hashId, row["book_id"], chapterStart, verseStart, fileName))
 				else:
 					del dbpMap[key]
 					(dbpChapterEnd, dbpVerseEnd, dbpFileName, dbpFileSize, dbpDuration) = dbpValue
 					# primary keys: "hash_id", "book_id", "chapter_start", "verse_start"
 					if chapterEnd != dbpChapterEnd:
-						updateRows.append(("chapter_end", chapterEnd, dbpChapterEnd, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("chapter_end", chapterEnd, dbpChapterEnd, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if verseEnd != dbpVerseEnd:
-						updateRows.append(("verse_end", verseEnd, dbpVerseEnd, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("verse_end", verseEnd, dbpVerseEnd, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if fileName != dbpFileName:
-						updateRows.append(("file_name", fileName, dbpFileName, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("file_name", fileName, dbpFileName, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if fileSize != dbpFileSize:
-						updateRows.append(("file_size", fileSize, dbpFileSize, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("file_size", fileSize, dbpFileSize, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 					if duration != dbpDuration and duration != None and duration != "":
-						updateRows.append(("duration", duration, dbpDuration, hashId, row["book_id"], chapterStart, verseStart))
+						updateRows.append(("duration", duration, dbpDuration, hashId, row["book_id"], chapterStart, verseStart, dbpFileName))
 
 		return (insertRows, updateRows, [])
 
@@ -356,23 +356,23 @@ class UpdateDBPFilesetTables:
 
 					if not dbp:
 						inserts.append((
-							c_end, v_end, filename, variant_file_size, duration, v_seq,
-							hash_id, row["book_id"], c_start, v_start
+							c_end, v_end, variant_file_size, duration, v_seq,
+							hash_id, row["book_id"], c_start, v_start, filename
 						))
 					else:
 						dbp_c_end, dbp_v_end, dbp_filename, dbp_size, dpb_dur = dbp
 
 						# primary keys: "hash_id", "book_id", "chapter_start", "verse_start"
 						if c_end   != dbp_c_end:
-							updates.append(("chapter_end", c_end, dbp_c_end, hash_id, row["book_id"], c_start, v_start))
+							updates.append(("chapter_end", c_end, dbp_c_end, hash_id, row["book_id"], c_start, v_start, dbp_filename))
 						if v_end   != dbp_v_end:
-							updates.append(("verse_end", v_end, dbp_v_end, hash_id, row["book_id"], c_start, v_start))
+							updates.append(("verse_end", v_end, dbp_v_end, hash_id, row["book_id"], c_start, v_start, dbp_filename))
 						if filename != dbp_filename:
-							updates.append(("file_name", filename, dbp_filename, hash_id, row["book_id"], c_start, v_start))
+							updates.append(("file_name", filename, dbp_filename, hash_id, row["book_id"], c_start, v_start, dbp_filename))
 						if variant_file_size  != dbp_size:
-							updates.append(("file_size", variant_file_size, dbp_size, hash_id, row["book_id"], c_start, v_start))
+							updates.append(("file_size", variant_file_size, dbp_size, hash_id, row["book_id"], c_start, v_start, dbp_filename))
 						if duration != dpb_dur and duration != None and duration != "":
-							updates.append(("duration", duration, dpb_dur, hash_id, row["book_id"], c_start, v_start))
+							updates.append(("duration", duration, dpb_dur, hash_id, row["book_id"], c_start, v_start, dbp_filename))
 
 				# 4) Anything left in dbp_map wasn’t seen → delete
 				deletes = [


### PR DESCRIPTION
# Description
Updated the unique constraint on bible_files to include the file_name column. The filename will now be taken into account when generating the update statement.

# Task
[Bug 2714](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2714): uploader: update bible_files needs another constraint

# How to test it
I have used the following 3 filesets to test: SPNBDAP2DV (video), ENGESVN2DA (audio) and Spanish_N2SPNTLA_USX (text) and the command:

```````shell
-> python3 load/UpdateDBPFilesetTables.py test s3://etl-development-input SPNBDAP2DV
# related outcome to update a bible_files
UPDATE bible_files SET file_name = 'Spanish-BDA_MAT_10-1-23_stream.m3u8' WHERE hash_id='b18563a987c4' AND book_id='MAT' AND chapter_start='10' AND verse_start='1' AND file_name='Spanish_BDA_MAT_10-1-23_stream.m3u8'; -- prior=Spanish_BDA_MAT_10-1-23_stream.m3u8

-> python3 load/UpdateDBPFilesetTables.py test s3://etl-development-input ENGESVN2DA
# related outcome to update a bible_files
UPDATE bible_files SET file_name = 'B01___01_Matthew_____ENGESVN2DA.mp3' WHERE hash_id='049d0c45b02f' AND book_id='MAT' AND chapter_start='1' AND verse_start='1' AND file_name='B01__01_Matthew_____ENGESVN2DA.mp3'; -- prior=B01__01_Matthew_____ENGESVN2DA.mp3

-> python3 load/UpdateDBPFilesetTables.py test s3://etl-development-input Spanish_N2SPNTLA_USX
# related outcome to update a bible_files
UPDATE bible_files SET file_name = '040MAT.usx' WHERE hash_id='998bba8ed906' AND book_id='MAT' AND chapter_start='1' AND verse_start='1' AND file_name='_040MAT.usx'; -- prior=_040MAT.usx
```````