### PR TITLE
Task-2717 uploader zip: remove leading "/"

### DIFF
--- a/load/S3ZipperService.py
+++ b/load/S3ZipperService.py
@@ -118,9 +118,9 @@ class S3ZipperService:
         # Replace empty string with "/" to explicitly denote the root directory.
         directories = {directory if directory else "/" for directory in directories}
 
-        # Build the file mapper content mapping each unique directory to "/".
+        # Build the file mapper content mapping each unique directory to "" (empty).
         file_mapper_content = {
-            "paths": [{"key": directory, "name": "/"} for directory in sorted(directories)]
+            "paths": [{"key": directory, "name": ""} for directory in sorted(directories)]
         }
         json_data = json.dumps(file_mapper_content)
 


### PR DESCRIPTION
# Description
fixed the s3zipper service so it no longer inserts a leading '/' when generating the mapper file. This prevents every file name from starting with '/'.

# Task
[Bug 2717](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2717): uploader zip: remove leading /

# How to test it
You can see the difference between two zip files before and after this change:

``````````shell
# Before
unzip -l SPNBDAP2DV_JHN.zip 
Archive:  SPNBDAP2DV_JHN.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      338  2025-04-25 15:12   /Spanish-BDA_JHN_10-1-21_web.mp4
      350  2025-04-25 15:12   /Spanish-BDA_JHN_End_Credits_web.mp4
---------                     -------
      688                     2 files

# After
unzip -l SPNBDAP2DV_MRK.zip 
Archive:  SPNBDAP2DV_MRK.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      338  2025-05-01 16:41   Spanish-BDA_MRK_10-1-16_web.mp4
      350  2025-05-01 16:41   Spanish-BDA_MRK_End_Credits_web.mp4
---------                     -------
      688                     2 files

```````````