### PR TITLE
Task-2714 (R)uploader: update bible_files needs another constraint

### DIFF
--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -375,11 +375,12 @@ class UpdateDBPFilesetTables:
 							updates.append(("duration", duration, dpb_dur, hash_id, row["book_id"], c_start, v_start, dbp_filename))
 
 				# 4) Anything left in dbp_map wasn’t seen → delete
-				deletes = [
-					(hash_id, book_id, c_start, v_start)
-					for (book_id, c_start, v_start, _) in dbp_map
-					if (book_id, c_start, v_start, _) not in seen_keys
-				]
+				deletes = []
+				for (book_id, chapter_start, verse_start, ext), value in dbp_map.items():
+					if (book_id, chapter_start, verse_start, ext) not in seen_keys:
+						# get the file name from the dbp_map
+						(_, _, dbp_file_name, _, _) = value
+						deletes.append((hash_id, book_id, chapter_start, verse_start, dbp_file_name))
 
 		return inserts, updates, deletes
 


### PR DESCRIPTION
# Description
Fixed the logic for deleting a bible_files record for video filesets. The issue occurred because file_name was added to the unique constraint, but it was not included in the DELETE statement's condition.

# Task
[Bug 2714](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2714): (R)uploader: update bible_files needs another constraint

# How to test it
I have used the filset: SPNBDAP2DV
``````shell
time python3 load/UpdateDBPFilesetTables.py test s3://etl-development-input SPNBDAP2DV

# outcome
DELETE FROM bible_files WHERE hash_id='b18563a987c4' AND book_id='MRK' AND chapter_start='10' AND verse_start='16' AND file_name='Spanish-BDA_MRK_10-16-21_web.mp4';
``````