### PR TITLE
Task-2760 uploader: update CPC failed

### DIFF
--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -188,8 +188,18 @@ class DBPLoadController:
 			add_product_code(zip_file)
 
 		if product_codes:
-			mondayService.synchronize(product_codes)
-			Log.getLogger(inputFileset.filesetId).message(Log.INFO, "Monday product codes synchronized")
+			RunStatus.statusMap[RunStatus.MONDAY] = RunStatus.NOT_DONE
+
+			try:
+				mondayService.synchronize(product_codes)
+				Log.getLogger(inputFileset.filesetId).message(Log.INFO, "Monday product codes synchronized")
+				RunStatus.set(RunStatus.MONDAY, True)
+			except Exception as e:
+				Log.getLogger(inputFileset.filesetId).message(
+					Log.EROR, f"Error synchronizing product codes: {', '.join(product_codes.keys())} error: {e}"
+				)
+				RunStatus.set(RunStatus.MONDAY, False)
+
 
 if (__name__ == '__main__'):
 	print("*** DBPLoadController *** ")
@@ -211,6 +221,7 @@ if (__name__ == '__main__'):
 		hasError = False
 		for inp in InputFileset.upload:
 			logger = Log.getLogger(inp.filesetId)
+
 			if logger.errorCount() > 0:
 				print("")
 				print("DBPLoadController:validate. fileset: %s has errors" %(inp.filesetId))

--- a/load/RunStatus.py
+++ b/load/RunStatus.py
@@ -13,6 +13,7 @@ from Log import *
 
 
 class RunStatus:
+	MONDAY = "UpdateMonday"
 	BIBLE = "BIBLE"
 	LPTS = "LPTS"
 	NOT_DONE = "not done"

--- a/load/TestMondayHTTP.py
+++ b/load/TestMondayHTTP.py
@@ -1,0 +1,107 @@
+import unittest
+from unittest import mock
+import json
+import requests
+
+from MondayHTTP import HTTPService
+
+# DummyResponse simulates requests.Response for testing
+class DummyResponse:
+    def __init__(self, status_code, text="", headers=None):
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers or {}
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+    @property
+    def content(self):
+        return self.text.encode("utf-8")
+
+class HTTPServiceTest(unittest.TestCase):
+    def setUp(self):
+        # Create service instance
+        self.svc = HTTPService("test-key", "http://example.com")
+        # Patch time.sleep to no-op and random.random for deterministic jitter
+        patch_sleep = mock.patch('time.sleep', lambda s: None)
+        patch_jitter = mock.patch('random.random', lambda: 0.5)
+        self.addCleanup(patch_sleep.stop)
+        self.addCleanup(patch_jitter.stop)
+        patch_sleep.start()
+        patch_jitter.start()
+
+    def make_seq_responses(self, responses):
+        """
+        Returns a side_effect function that either raises or returns items from responses list.
+        """
+        seq = list(responses)
+        def side_effect(url, data, headers, timeout):
+            item = seq.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        return side_effect
+
+    def test_429_then_success(self):
+        # 429 with Retry-After=0 then success
+        responses = [
+            DummyResponse(429, text='{"errors":[{"message":"Rate limit"}]}', headers={"Retry-After": "0"}),
+            DummyResponse(200, text='{"data":{"ok":true}}'),
+        ]
+        with mock.patch('requests.post', side_effect=self.make_seq_responses(responses)):
+            out = self.svc.make_monday_api_call(b'{}')
+            self.assertEqual(json.loads(out), {"data": {"ok": True}})
+
+    def test_server_error_retries_then_success(self):
+        for status in (500, 502, 503, 504):
+            with self.subTest(status=status):
+                responses = [
+                    DummyResponse(status, text="Server error"),
+                    DummyResponse(200, text='{"data":{"ok":true}}'),
+                ]
+                with mock.patch('requests.post', side_effect=self.make_seq_responses(responses)):
+                    out = self.svc.make_monday_api_call(b'{}')
+                    self.assertIs(json.loads(out)["data"]["ok"], True)
+
+    def test_network_error_then_success(self):
+        responses = [
+            requests.RequestException("conn reset"),
+            DummyResponse(200, text='{"data":{"ok":true}}'),
+        ]
+        with mock.patch('requests.post', side_effect=self.make_seq_responses(responses)):
+            out = self.svc.make_monday_api_call(b'{}')
+            self.assertIs(json.loads(out)["data"]["ok"], True)
+
+    def test_retry_exhaustion_raises(self):
+        # Always return 429 to exhaust retries
+        response = DummyResponse(429, text="Still bad", headers={"Retry-After": "0"})
+        with mock.patch('requests.post', return_value=response):
+            with self.assertRaises(RuntimeError) as cm:
+                self.svc.make_monday_api_call(b'{}')
+            self.assertIn("failed after", str(cm.exception))
+
+    def test_non_retryable_status_immediate_failure(self):
+        for status in (400, 401, 403, 404):
+            with self.subTest(status=status):
+                response = DummyResponse(status, text="Client error")
+                with mock.patch('requests.post', return_value=response):
+                    with self.assertRaises(ValueError) as cm:
+                        self.svc.make_monday_api_call(b'{}')
+                    self.assertIn("Empty response", str(cm.exception))
+
+    def test_429_retry_after_nonzero(self):
+        """
+        429 Too Many Requests with Retry-After > 0 then success on retry.
+        """
+        responses = [
+            DummyResponse(429, text='{"errors":[{"message":"Rate limit exceeded"}]}', headers={"Retry-After": "4"}),
+            DummyResponse(200, text='{"data":{"ok":true}}'),
+        ]
+        with mock.patch('requests.post', side_effect=self.make_seq_responses(responses)):
+            out = self.svc.make_monday_api_call(b'{}')
+            self.assertEqual(json.loads(out), {"data": {"ok": True}})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description
While investigating Task 2760, I reproduced the issue that occurs when for example the Monday API key in the cfg file is incorrect. A wrong key results in a 401 response, but the existing code handled it the same way as a network error or an empty response.

To address this, I improved the class: "load/MondayHTTP.py" so that Monday HTTP server errors (e.g. 401 responses) are reported in greater detail.

Added a new RunStatus component, UpdateMonday, for each fileset to indicate whether ETL succeeds or fails in updating Monday. Added logic to treat all 4xx and 5xx responses as retryable errors. Increased the retry delay to 1.5 seconds and applied exponential back-off.

Here’s an updated MondayHTTP.py with a proper exponential-backoff retry loop that:

- Retries on 429, 500, 502, 503, and 504
- Respects the Retry-After header when present (especially for 429)
- Applies jitter to avoid thundering-herd
- Logs all 401, 400, 403 and 404 errors immediately.
- New unit test for MondayHTTP

# Task
[Bug 2760](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2760): uploader: update CPC failed

# How to test it
I have used the following command and I have set a wrong Monday API key to see the following outcome with the detail of the error:
``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "SPNBDAP2DV"

# outcome
Database 'dbp_2025_03_06' is opened.
sendRequest: Rate limited (429). Retry-After=12 sec. Response: {"errors":["Rate limit exceeded"]}
Retryable HTTP error (status=429) on attempt 1/5: HTTP 429. Sleeping 17.8 seconds before retry…
sendRequest: Rate limited (429). Retry-After=12 sec. Response: {"errors":["Rate limit exceeded"]}
Retryable HTTP error (status=429) on attempt 2/5: HTTP 429. Sleeping 15.6 seconds before retry…
sendRequest: Rate limited (429). Retry-After=12 sec. Response: {"errors":["Rate limit exceeded"]}
Retryable HTTP error (status=429) on attempt 3/5: HTTP 429. Sleeping 17.4 seconds before retry…
sendRequest: Rate limited (429). Retry-After=12 sec. Response: {"errors":["Rate limit exceeded"]}
Retryable HTTP error (status=429) on attempt 4/5: HTTP 429. Sleeping 12.9 seconds before retry…
sendRequest: Rate limited (429). Retry-After=12 sec. Response: {"errors":["Rate limit exceeded"]}
Retryable HTTP error (status=429) on attempt 5/5: HTTP 429. Sleeping 14.9 seconds before retry…
make_monday_api_call failed after 5 attempts
********** SPNBDAP2DV-UpdateMonday Tables Update failed **********
Warnings:
WARN SPNBDAP2DV chapters missing JHN 1-9, JHN 11-21, LUK 1-9, LUK 11-24, MAT 1-9, MAT 11-28, MRK 1-9, MRK 11-16
WARN SPNBDAP2DV BiblebrainLink does not have a correct path: No zip file found
openErrorReport /home/vichugof/files/errors/Errors.out
EROR SPNBDAP2DV Error synchronizing product codes: N2SPN/BDA_JHN, N2SPN/BDA_LUK, N2SPN/BDA_MAT, N2SPN/BDA_MRK error: make_monday_api_call failed after 5 attempts
Num Errors 1
Error in RunStatus {'SPNBDAP2DV': 'ok', 'UpdateMonday': 'failed'}
``````