### PR TITLE
Task-2712 uploader: for failed attempt, content is still being stored to S3

### DIFF
--- a/load/FilenameParser.py
+++ b/load/FilenameParser.py
@@ -476,6 +476,13 @@ class FilenameParser:
 
 			FilenameReducer.openAcceptErrorSet(self.config)
 			reducer = FilenameReducer(self.config, prefix, inp.csvFilename, files, extraChapters, missingChapters, missingVerses)
+			# Does not allow continue if there are errors related to the fileset parsing
+			# It will write the errors to the error file including the FilenameReducer errors
+			if numErrors > 0:
+				reducer.writeErrors(logger)
+				print("")
+				return False
+
 			reducer.process(logger)
 		print("")
 

--- a/load/FilenameReducer.py
+++ b/load/FilenameReducer.py
@@ -9,7 +9,6 @@
 # 
 
 import sys
-import io
 import os
 from operator import attrgetter
 import csv
@@ -17,7 +16,6 @@ from datetime import datetime
 from Config import *
 from Log import *
 from FindDuplicateFilesets import *
-from DBPRunFilesS3 import *
 
 class FilenameReducer:
 
@@ -126,7 +124,7 @@ class FilenameReducer:
 		"""
 		Processes the given list of file objects and writes a CSV output to the designated directory based on listType.
 		It calculates the maximum chapter and verse per book to set verse start numbers for "end" chapter files, sorts the file list,
-		and then writes the CSV file before uploading it via DBPRunFilesS3.
+		and then writes the CSV file.
 
 		Parameters:
 		- listType: A string indicating the type ("accepted", "duplicate", or "quarantine").
@@ -182,7 +180,7 @@ class FilenameReducer:
 					f.setVerseStartNum(verseStartNum)
 					f.setVerseStart(str(verseStartNum))
 
-		filename = path + os.path.basename(self.csvFilename)
+		filename = os.path.join(path, os.path.basename(self.csvFilename))
 		print("FilenameReducer. Create file: ", filename)
 		with open(filename, 'w', newline='\n') as csvfile:
 			writer = csv.writer(csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
@@ -196,8 +194,6 @@ class FilenameReducer:
 					file.file, file.bookId, file.name, file.chapter, file.chapterEnd, 
 					file.verseStart, file.verseStartNum, file.verseEnd, file.datetime, file.length,
 					"; ".join(file.errors)))
-		DBPRunFilesS3.uploadParsedCSV(self.config, filename)
-
 
 	def writeErrors(self, logger):
 		logger.fileErrors(self.fileList)


### PR DESCRIPTION
# Description
Fix the loading process to prevent uploading content if the process fails (e.g., due to file parsing errors). Currently, it uploads the CSV file regardless of whether an error occurs.

# Task
[Bug 2712](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2712): uploader: for failed attempt, content is still being stored to S3

# How to test it
- You should run the following command and I have to get the following output:
```````shell
time python3 load/DBPLoadController.py test s3://dbp-etl-upload-newdata-fiu49s0cnup1yr0q/ "2025-04-28-20-53-43/YAOGOIP1DA"
```````
- You can see that it only uploaded the Errors.out file.
![Screenshot from 2025-06-13 09-04-19](https://github.com/user-attachments/assets/22e784df-697b-4dd8-974c-4d7264f6407d)

- Output
``````shell
*** DBPLoadController *** 
Config:setConfigParametersFromProfile. profile: test, programRunning: DBPLoadController.py
Config 'test' is loaded.
Config:setConfigParametersFromProfile. profile: test, programRunning: DBPLoadController.py
Config 'test' is loaded.
AWSSession...assume role arn is not provided. If this is not a docker execution, check dbp-etl.cfg and verify there is a value for s3.aws_role_arn (previously, it was s3.aws_role)
Database 'dbp_2025_03_06' is opened.
Migration Stage: B 
Processing Content Load
LanguageReader requested: [BLIMP]
Config:setConfigParametersFromProfile. profile: test, programRunning: DBPLoadController.py
Config 'test' is loaded.
InputProcessor.commandLineProcessor.. path: 2025-04-28-20-53-43/YAOGOIP1DA, directory: YAOGOIP1DA
No stocknumber.txt file found. bucket [dbp-etl-upload-newdata-fiu49s0cnup1yr0q], fullPath: [2025-04-28-20-53-43/YAOGOIP1DA], key [2025-04-28-20-53-43/YAOGOIP1DA/stocknumber.txt]
PreValidate.validateDBPETL. after call to getStocknumberStringFromS3. stocknumberString: None 
TextStocknumberProcessor.validateTextStockNumbersFromController entry... stocknumberFileContentsString: None, directoryName: YAOGOIP1DA, location: s3://dbp-etl-upload-newdata-fiu49s0cnup1yr0q, fullPath 2025-04-28-20-53-43/YAOGOIP1DA 
TextStocknumberProcessor.getStockNumberList, returning stockNumberList from parsing Directory name: YAOGOIP1DA, stocknumberList: None
PreValidate.validateDBPETL. line 66. stocknumberResultList  was not >0.. validate filesetid from directoryName: YAOGOIP1DA
PreValidate.validateFilesetId. directoryName: YAOGOIP1DA, filesetId: YAOGOIP1DA, filesetId1: YAOGOIP1DA 
Database 'dbp_2025_03_06' is opened.
Database 'dbp_2025_03_06' is opened.
PreValidate.validateFilesetId. damId: YAOGOIP1DA check1: results: {(<BlimpLanguageRecord.BlimpLanguageRecord object at 0x78e1a483f370>, 'Live', 'Audio')}
PreValidate.validateFilesetId. didn't return error.. languageRecord: <BlimpLanguageRecord.BlimpLanguageRecord object at 0x78e1a483f370>, fieldName: Audio
PreValidate.validateFilesetId. regStockNumber: P1YAO/GOI
PreValidate.validateFilesetId. damId: YAOGOIP1DA
PreValidate.validateFilesetId. index: 1, bibleId: YAOGOI
PreValidate.validateFilesetId. mediaSet and bibleIdSet not empty. return PreValidateResult..
PreValidate.validateDBPETL. result from validateFilesetId: <PreValidateResult.PreValidateResult object at 0x78e1a483f250>
PreValidate.validateDBPETL. result from validateFilesetId was not empty, so validateLPTS ???
Config:setConfigParametersFromProfile. profile: test, programRunning: DBPLoadController.py
Config 'test' is loaded.
Database 'dbp_2025_03_06' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: DBPLoadController.py
Config 'test' is loaded.
Database 'dbp_2025_03_06' is opened.
Config:setConfigParametersFromProfile. profile: test, programRunning: DBPLoadController.py
Config 'test' is loaded.
Database 'dbp_2025_03_06' is opened.
InputProcessor.commandLineProcessor.. data: <PreValidateResult.PreValidateResult object at 0x78e1a483f250>
InputFileset construction. filesetId: YAOGOIP1DA location: s3://dbp-etl-upload-newdata-fiu49s0cnup1yr0q
Database 'dbp_2025_03_06' is opened.

*** DBPLoadController:validate ***
Database 'dbp_2025_03_06' is opened.

Found 1 filesets to process
FilenameParser: audio/YAOGOI/YAOGOIP1DA typeCode: audio

DBPLoadController:validate. fileset: YAOGOIP1DA, csvFilename: /home/vichugof/files/accepted/audio_YAOGOI_YAOGOIP1DA.csv 
DBPLoadController:validate. fileset: YAOGOIP1DA not added added to upload list
********** YAOGOIP1DA Tables Update failed **********
Warnings:
WARN YAOGOIP1DA chapters missing EXO 21-40
openErrorReport /home/vichugof/files/errors/Errors.out
EROR YAOGOIP1DA YAOGOIP1DA/YAOGOIP1DA_A02_EXO_006.014-006_027.mp3 no regex match to audioStory1.
Num Errors 1
Error in RunStatus {'YAOGOIP1DA': 'failed'}

real	0m2.788s
user	0m0.358s
sys	0m0.055s

```````