### PR TITLE
Task-2800 include copyright pdf in zip files created by uploader

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -22,6 +22,7 @@ s3.vid_bucket = ${S3_VID_BUCKET}
 s3.artifacts_bucket = ${S3_ARTIFACTS_BUCKET}
 s3.zipper.user_key = ${S3_ZIPPER_USER_KEY}
 s3.zipper.user_secret = ${S3_ZIPPER_USER_SECRET}
+biblebrain.services.base_url = ${BIBLEBRAIN_SERVICES_BASE_URL}
 directory.upload_aws = /efs/${S3_KEY_PREFIX}/etl_uploader/upload_aws/
 directory.upload = /efs/${S3_KEY_PREFIX}/etl_uploader/upload/
 directory.database = /efs/${S3_KEY_PREFIX}/etl_uploader/database/


### PR DESCRIPTION
# Description
Add the new environment variable related to the BibleBrain services URL to the .sh script that creates the dbp-etl.cfg file during deployment.

# Task
[User Story 2800](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2800): include copyright pdf in zip files created by uploader

# How to test it
- Run the deployment process and validate that the new env variable: `BIBLEBRAIN_SERVICES_BASE_URL` has been created