### PR TITLE
Task-2800: Fix the path used to push the PDF for video content

### DIFF
--- a/load/UpdateDBPBibleFilesSecondary.py
+++ b/load/UpdateDBPBibleFilesSecondary.py
@@ -117,10 +117,10 @@ class UpdateDBPBibleFilesSecondary:
 						fileset_id=inp.filesetId,
 						bible_id=inp.bibleId,
 						type_code=inp.typeCode,
-						bucket=self.config.s3_bucket,
+						bucket=self.config.s3_vid_bucket,
 						prefix=inp.filesetPrefix
 					)
-					complete_files.append(f"{self.config.s3_bucket}/{inp.filesetPrefix}/{package_id}.pdf")
+					complete_files.append(f"{self.config.s3_vid_bucket}/{inp.filesetPrefix}/{package_id}.pdf")
 					print(f"Uploaded PDF for fileset {inp.filesetId} → {package_id}.pdf")
 				except RuntimeError as e:
 					print(f"PDF step skipped for {inp.filesetId}: {e}")


### PR DESCRIPTION
# Description
Fix the path used to push the PDF for video content. This update corrects the bucket name to use dbp-vid-ENVIRONMENT instead of dbp-ENVIRONMENT.

# Task
[User Story 2800](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2800): include copyright pdf in zip files created by uploader[User Story 2800](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2800): include copyright pdf in zip files created by uploader

# How test it
I have used the following command to test it:

``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"
````````