### PR TITLE
Task-2844 Uploader: Use product code to generate the copyright PDF

### DIFF
--- a/load/UpdateDBPBibleFilesSecondary.py
+++ b/load/UpdateDBPBibleFilesSecondary.py
@@ -64,6 +64,7 @@ class UpdateDBPBibleFilesSecondary:
 				package_id = self._fetch_and_upload_pdf(
 					fileset_id=inp.filesetId,
 					bible_id=inp.bibleId,
+					book_id=None,  # No book_id for audio filesets
 					type_code=inp.typeCode,
 					bucket=self.config.s3_bucket,
 					prefix=inp.filesetPrefix
@@ -116,6 +117,7 @@ class UpdateDBPBibleFilesSecondary:
 					package_id = self._fetch_and_upload_pdf(
 						fileset_id=inp.filesetId,
 						bible_id=inp.bibleId,
+						book_id=book_id,
 						type_code=inp.typeCode,
 						bucket=self.config.s3_vid_bucket,
 						prefix=inp.filesetPrefix
@@ -158,7 +160,7 @@ class UpdateDBPBibleFilesSecondary:
 				create_zip_for_fileset(cov_book_id, files)
 
 
-	def _fetch_and_upload_pdf(self, fileset_id: str, bible_id: str, type_code: str, bucket: str, prefix: str) -> str:
+	def _fetch_and_upload_pdf(self, fileset_id: str, bible_id: str, type_code: str, book_id: str|None, bucket: str, prefix: str) -> str:
 		"""
 		Calculates the product code, fetches the PDF, and uploads it to S3.
 		Returns the package ID (sans .pdf).
@@ -167,9 +169,9 @@ class UpdateDBPBibleFilesSecondary:
 		languageRecord, _ = self.languageReader.getLanguageRecordLoose(
 			type_code, bible_id, fileset_id
 		)
-		# We are going to assume that the stock number is the product code, however, this may not always be the case.
-		# It is possible that we need to use the product code instead of stock number in the future.
-		product_code = languageRecord.StockNumberByFilesetId(fileset_id)
+
+		product_code = languageRecord.CalculateProductCode(fileset_id, type_code, book_id)
+
 		if not product_code:
 			raise RuntimeError("No product code returned")
 


### PR DESCRIPTION
# Description

Following the latest update to the Biblebrain-Services API, this PR changes the logic to generate the copyright PDF using the product code rather than the stock number.

# Task
[Bug 2844](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2844): Uploader: Use product code to generate the copyright PDF

# How to test it
I have tested using the following two command and I have validated that the zip file contains the copyright pdf:

- Audio Content
``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "ENGESVN2DA"
```````
- Video Content

``````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"
```````
