### PR TITLE
Task-2844 The logic for updating the bible_files_secondary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lambda/**/*.zip
 lambda/**/dbp-etl.cfg
 .vscode/
 FilenameParser.out
+CLAUDE.md

--- a/load/DBPLoadController.py
+++ b/load/DBPLoadController.py
@@ -93,6 +93,23 @@ class DBPLoadController:
 		secondary.createAllZipFiles(inputFilesets)
 		Log.writeLog(self.config)
 
+	def updateFilesSecondary(self, inputFilesets):
+		""" Update the secondary files for the given input filesets.
+		This method processes each input fileset and updates the secondary files in the database.
+		"""
+		print("\n*** DBPLoadController:updateFilesSecondary ***")
+		dbOut = SQLBatchExec(self.config)
+		update = UpdateDBPFilesetTables(self.config, self.db, dbOut, self.languageReader)
+		for inp in inputFilesets:
+			update.processFilesSecondary(inp)
+			dbOut.displayCounts()
+			success = dbOut.execute(inp.batchName() + "-secondary")
+
+			RunStatus.set(inp.filesetId, success)
+
+			if not success:
+				print("********** Fileset Table %s Update Files Secondary Failed **********" % (inp.filesetId))
+
 	def updateFilesetTables(self, inputFilesets):
 		print("\n*** DBPLoadController:updateFilesetTables ***")
 		inp = inputFilesets
@@ -245,6 +262,8 @@ if (__name__ == '__main__'):
 				# e.g. we need to have the product code and stock number in the fileset tables
 				# before we can upload the secondary files
 				ctrl.uploadSecondaryFiles(InputFileset.upload)
+				# Once the secondary files are uploaded, we can process them and store the reference in the database
+				ctrl.updateFilesSecondary(InputFileset.upload)
 			for inputFileset in InputFileset.complete:
 				print("Completed: ", inputFileset.filesetId)
 				ctrl.synchronizeMonday(inputFileset)
@@ -377,5 +396,7 @@ if (__name__ == '__main__'):
 
 # time python3 load/DBPLoadController.py test s3://etl-development-input/ "SPNBDAP2DV"
 # time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"
+
+# time python3 load/DBPLoadController.py test s3://etl-development-input/ "BUNBSLN1DA"
 
 # time python3 load/DBPLoadController.py test s3://dbp-etl-upload-newdata-fiu49s0cnup1yr0q/ "2025-04-28-20-53-43/YAOGOIP1DA"


### PR DESCRIPTION
# Description
Update the logic to insert rows into the bible_files_secondary entity. The logic for updating the bible_files_secondary entity has been separated into a different method. It is now invoked after the product code has been inserted and the ZIP file has been generated.

# Task
[Bug 2844](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2844): Uploader: Use product code to generate the copyright PDF

# Screenshot
You can check int the dev uploader environment the changes according to the test using BUNBSLN1DA
![Screenshot from 2025-07-02 17-35-00](https://github.com/user-attachments/assets/43dd6b70-2832-4b33-bae2-ae25b6c7c535)

# How to test it
I have used the following command to test these changes:
`````````shell
time python3 load/DBPLoadController.py test s3://etl-development-input/ "BUNBSLN1DA"
````````` 