### PR TITLE
Task-2655 Create mock transcoder for dev environment

### DIFF
--- a/load/AWSSession.py
+++ b/load/AWSSession.py
@@ -32,11 +32,20 @@ class AWSSession:
 		# for docker execution, assume_role_arn is provided by ECS task configuration
 		if self.config.s3_aws_role_arn == None:
 			print ("AWSSession...assume role arn is not provided. If this is not a docker execution, check dbp-etl.cfg and verify there is a value for s3.aws_role_arn (previously, it was s3.aws_role)")
+			client_args = {
+				'service_name': clientType,
+			}
+
+			# set endpoint_url if provided in config
+			# this is used for local testing with docker container
+			# and for testing with mock elastic transcoder
+			if hasattr(self.config, 'video_transcoder_url') and self.config.video_transcoder_url is not None and clientType == "elastictranscoder":
+				client_args['endpoint_url'] = self.config.video_transcoder_url
 			if timeout != None:
-				botoConfig = BotoConfig(retries={'max_attempts': 0}, read_timeout = timeout, connect_timeout = timeout)
-				client = session.client(clientType, config = botoConfig)
-			else:
-				client = session.client(clientType)
+				boto_config = BotoConfig(retries={'max_attempts': 0}, read_timeout = timeout, connect_timeout = timeout)
+				client_args['config'] = boto_config
+
+			client = session.client(**client_args)
 			return client 
 			
 		# assume_role_arn explicitely provided
@@ -53,14 +62,21 @@ class AWSSession:
 			botoConfig = BotoConfig(retries={'max_attempts': 0}, read_timeout = timeout, connect_timeout = timeout)
 
 		#print ("connect timeout: %s, read_timeout: %s" % (botoConfig.connect_timeout,botoConfig.read_timeout))
-		client = boto3.client(
-	    	clientType,
-	    	aws_access_key_id = credentials['AccessKeyId'],
-	    	aws_secret_access_key = credentials['SecretAccessKey'],
-	    	aws_session_token = credentials['SessionToken'],
-	    	region_name = regionName,
-	    	config = botoConfig
-		)
+		client_args = {
+			'service_name': clientType,
+			'aws_access_key_id': credentials['AccessKeyId'],
+			'aws_secret_access_key': credentials['SecretAccessKey'],
+			'aws_session_token': credentials['SessionToken'],
+			'region_name': regionName,
+			'config': botoConfig
+		}
+		# set endpoint_url if provided in config
+		# this is used for local testing with docker container
+		# and for testing with mock elastic transcoder
+		if hasattr(self.config, 'video_transcoder_url') and self.config.video_transcoder_url is not None and clientType == "elastictranscoder":
+			client_args['endpoint_url'] = self.config.video_transcoder_url
+
+		client = boto3.client(**client_args)
 		print("Created role %s based session for %s." % (self.config.s3_aws_role_arn, clientType))
 		return client
 

--- a/load/AWSTranscoder.py
+++ b/load/AWSTranscoder.py
@@ -33,21 +33,13 @@ class AWSTranscoder:
 		self.url = None
 		self.key = None
 
+
 	def setAudioTranscoderParameters(self):
-		if hasattr(self.config, 'audio_transcoder_mock') and self.config.audio_transcoder_mock != None:
-			audio_transcoder_mock = {}
-
-			try:
-				audio_transcoder_mock = json.loads(self.config.audio_transcoder_mock)
-			except json.JSONDecodeError:
-				# Handle the error and set a empty dict for self.audio_transcoder_mock
-				audio_transcoder_mock = {}
-
-			if audio_transcoder_mock.get("enable") == 1:
-				self.url = audio_transcoder_mock.get("endpoint_url")
-				self.key = audio_transcoder_mock.get("key")
-				return True
-
+		"""Sets the audio transcoder parameters.
+		If it is mocked, it will return the mock client.
+		Otherwise, it will return the real AWS audio transcoder client.
+		Set the audio.transcoder.url and audio.transcoder.key in dbp-etl.cfg to use the audio transcoder.
+		"""
 		self.url = self.config.audio_transcoder_url
 		self.key = self.config.audio_transcoder_key
 

--- a/load/Config.py
+++ b/load/Config.py
@@ -163,7 +163,6 @@ class Config:
 		if profile == 'test':
 			# video
 			self.video_transcoder_pipeline = self._get("video.transcoder.pipeline")
-			self.video_transcoder_mock = self._get("video.transcoder.mock")
 			self.video_transcoder_region = self._get("video.transcoder.region")
 			self.video_preset_hls_1080p = self._get("video.preset.hls.1080p")
 			self.video_preset_hls_720p = self._get("video.preset.hls.720p")
@@ -171,11 +170,11 @@ class Config:
 			self.video_preset_hls_360p = self._get("video.preset.hls.360p")
 			self.video_preset_web = self._get("video.preset.web")
 			# audio
-			self.audio_transcoder_mock = self._get("audio.transcoder.mock")
 			self.audio_transcoder_sleep_sec = self._getInt("audio.transcoder.sleep.sec")
 			self.audio_transcoder_input = self._get("audio.transcoder.input")
 
 		if profile in {'test', 'dev'}:
+			self.video_transcoder_url = self._get("video.transcoder.url")
 			self.database_names['dbp'] = self.hashMap.get("database.db_name")
 			self.database_names['user_dbp'] = self.hashMap.get("database.user_db_name")
 			self.database_host = self._get("database.host")

--- a/load/TranscodeVideo.py
+++ b/load/TranscodeVideo.py
@@ -42,20 +42,11 @@ class TranscodeVideo:
 		self.openJobs = []
 
 	def getTranscoderClient(self):
-		if hasattr(self.config, 'video_transcoder_mock') and self.config.video_transcoder_mock != None:
-			try:
-				self.video_transcoder_mock = json.loads(self.config.video_transcoder_mock)
-			except json.JSONDecodeError:
-				# Handle the error and set a empty dict for self.video_transcoder_mock
-				self.video_transcoder_mock = {}
-
-			if self.video_transcoder_mock.get("enable") == 1:
-				return boto3.client(
-					'elastictranscoder',
-					region_name=self.video_transcoder_mock.get("region_name"),
-					endpoint_url=self.video_transcoder_mock.get("endpoint_url")
-				)
-
+		"""Returns the Elastic Transcoder client.
+		If it is mocked, it will return the mock client.
+		Otherwise, it will return the real AWS Elastic Transcoder client.
+		Set the video.transcoder.url in dbp-etl.cfg to use the mock client.
+		"""
 		return AWSSession.shared().elasticTranscoder()
 
 	def createJob(self, file):

--- a/load/UpdateDBPFilesetTables.py
+++ b/load/UpdateDBPFilesetTables.py
@@ -203,7 +203,7 @@ class UpdateDBPFilesetTables:
 		if typeCode == "text":
 			existingBookIdSet = dbConn.selectSet("SELECT book_id FROM bible_verses WHERE hash_id = %s", (hashId,))
 		else:
-			existingBookIdSet = dbConn.selectSet("SELECT book_id FROM bible_files WHERE hash_id = %s", (hashId,))			
+			existingBookIdSet = dbConn.selectSet("SELECT book_id FROM bible_files WHERE hash_id = %s", (hashId,))
 		fullBookIdSet = existingBookIdSet.union(bookIdSet)
 		otBooks = fullBookIdSet.intersection(self.OT)
 		ntBooks = fullBookIdSet.intersection(self.NT)


### PR DESCRIPTION
# Description
Improve the mock configurations for the audio and video transcoders.

With these changes, we can continue using the existing configuration keys for the audio transcoder and we have added a single configuration key `mock_video_transcoder_url` to specify the mock video transcoder’s URL. In production, ETL will use the default endpoint_url, if `mock_video_transcoder_url` is set, ETL will use that URL instead.

# How to test it
I have used the following two command to test it:

``````shell
# audio content
time python3 load/DBPLoadController.py test s3://etl-development-input/ "BUNBSLN1DA"

# video content
time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"
```````