### PR TITLE
Task-2856 uploader (video): include book in copyright  pdf

### DIFF
--- a/load/UpdateDBPBibleFilesSecondary.py
+++ b/load/UpdateDBPBibleFilesSecondary.py
@@ -178,6 +178,9 @@ class UpdateDBPBibleFilesSecondary:
 		# Build S3 key
 		# For now, we will use a fixed package_id (copyright) for copyright PDFs
 		package_id = "copyright"
+		if book_id is not None:
+			# For book-specific PDFs, use the book_id as the package_id (video filesets)
+			package_id = f"{package_id}_{book_id}"
 		pdf_key = f"{prefix}/{package_id}.pdf"
 
 		# Fetch & upload


### PR DESCRIPTION
# Description
Include the book in the copyright PDF when the fileset contains video content.

# Task
[User Story 2856](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2856): uploader (video): include book in copyright  pdf

# How to test it

```````shell
-> time python3 load/DBPLoadController.py test s3://etl-development-input/ "FANBSGP2DV"
# output
Starting zip process with payload: bucket: dbp-vid-staging file_paths: ['dbp-vid-staging/video/FANBSG/FANBSGP2DV/copyright_ACT.pdf'] zip_output_prefix: video/FANBSG/FANBSGP2DV/FANBSGP2DV_ACT.zip fileMapper: dbp-vid-staging/video/FANBSG/FANBSGP2DV/fileMapper_20250714T181421.json

-> time python3 load/DBPLoadController.py test s3://etl-development-input/ "BUNBSLN1DA"
# output
Starting zip process with payload: bucket: dbp-staging file_paths: ['dbp-staging/audio/BUNBSL/BUNBSLN1DA/copyright.pdf'] zip_output_prefix: audio/BUNBSL/BUNBSLN1DA/BUNBSLN1DA.zip fileMapper: dbp-staging/audio/BUNBSL/BUNBSLN1DA/fileMapper_20250714T181102.json
```````