### PR TITLE
Task-2932 Add the ACL attribute to the method that uploads the S3Zipp…

### DIFF
--- a/load/S3ZipperService.py
+++ b/load/S3ZipperService.py
@@ -138,7 +138,8 @@ class S3ZipperService:
             Bucket=bucket_name,
             Key=file_mapper_key,
             Body=json_data,
-            ContentType='application/json'
+            ContentType='application/json',
+            ACL='bucket-owner-full-control',
         )
         # print(f"Uploaded fileMapper.json to s3://{bucket_name}/{file_mapper_key}")
         return file_mapper_key
@@ -164,7 +165,6 @@ class S3ZipperService:
         self.s3_client.delete_object(Bucket=bucket_name, Key=file_mapper_key)
         # print(f"Deleted fileMapper.json from s3://{bucket_name}/{file_mapper_key}")
 
-    # def zip_files(self, bucket_name, file_paths, zip_file_name):
     def zip_files(self, bucket_name, file_paths, zip_output_prefix):
         """
         Create a zip of specified `file_paths` in `bucket_name` using s3zipper's /v2/zipstart endpoint
@@ -183,7 +183,8 @@ class S3ZipperService:
         start_url = f"{S3ZIPPER_BASE_URL}/v2/zipstart"
         headers = {
             "Authorization": f"Bearer {self.s3zipper_token}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "x-amz-acl": "bucket-owner-full-control",
         }
         payload = {
             "awsKey": self.aws_access_key_id,
@@ -403,3 +404,4 @@ if __name__ == "__main__":
 
 # time python3 load/S3ZipperService.py test etl-development-input '["etl-development-input/audio/ENGESV/ENGESVN2DA/B01___01_Matthew_____ENGESVN2DA.mp3"]'
 # time python3 load/S3ZipperService.py test dbp-staging '["dbp-staging/audio/ENGESV/ENGESVN2DA/B01___01_Matthew_____ENGESVN2DA.mp3"]'
+# time python3 load/S3ZipperService.py test dbp-vid-staging '["dbp-vid-staging/video/ENGESV/ENGESVP2DV/English_ESV_MRK_9-1-13.mp4"]'


### PR DESCRIPTION
# Description
Add the ACL attribute to the method that uploads the S3Zipper JSON mapper and to the header of the request that starts the S3Zipper process.

# Task
[User Story 2932](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2932): uploader: replace call to AWS Elastic Transcoder with call to services API media/transcode

# How to test it
I have used the following command to test that the owner of the zip created file is dbs in dbp-staging

```````shell
aws s3 rm "s3://dbp-vid-staging/s3zipper/python-test.zip"
aws s3 ls "s3://dbp-vid-staging/s3zipper/"
time python3 load/S3ZipperService.py test dbp-vid-staging '["dbp-vid-staging/video/ENGESV/ENGESVP2DV/English_ESV_MRK_9-1-13.mp4"]'
aws s3 ls "s3://dbp-vid-staging/s3zipper/"
aws s3api get-object-acl --bucket dbp-vid-staging --key "s3zipper/python-test.zip" --region us-west-2 --profile dbp-etl-dev

# outcome
{
    "Owner": {
        "DisplayName": "dbs",
        "ID": "4cac7a8af95fXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
    },
    "Grants": [
        {
            "Grantee": {
                "DisplayName": "dbs",
                "ID": "4cac7a8af95fXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
                "Type": "CanonicalUser"
            },
            "Permission": "FULL_CONTROL"
        }
    ]
}

```````